### PR TITLE
perf(tail_log): re-enable LRU render cache for markup lines

### DIFF
--- a/pgtail_py/tail_log.py
+++ b/pgtail_py/tail_log.py
@@ -684,6 +684,14 @@ class TailLog(Log):
         Overrides parent to parse Rich console markup in log lines,
         enabling colored output for log levels, timestamps, etc.
 
+        Uses the inherited ``_render_line_cache`` (LRU, 1024 slots) so
+        that lines which haven't changed are not re-parsed through
+        ``Text.from_markup()`` on every frame.  The cache is bypassed
+        whenever a text selection is active (selection styling varies
+        per-render) and is cleared automatically by the parent on
+        ``clear()``, ``notify_style_update()``, ``selection_updated()``,
+        and ``_prune_max_lines()``.
+
         Args:
             y: Y offset of line.
             rich_style: Base Rich style for line.
@@ -692,8 +700,8 @@ class TailLog(Log):
             Strip with rendered line content.
         """
         selection = self.text_selection
-        # Skip cache to ensure markup is always parsed
-        # TODO: Re-enable cache after markup rendering confirmed working
+        if selection is None and y in self._render_line_cache:
+            return self._render_line_cache[y]
 
         _line = self._process_line(self._lines[y])
 
@@ -720,4 +728,7 @@ class TailLog(Log):
 
         app: Any = self.app  # type: ignore[assignment]
         line = Strip(line_text.render(app.console), line_text.cell_len)
+
+        if selection is None:
+            self._render_line_cache[y] = line
         return line

--- a/tests/test_cli_tail_filters.py
+++ b/tests/test_cli_tail_filters.py
@@ -69,7 +69,6 @@ class TestHandleFilterCommand:
         """Plain /pattern/ sets include filter."""
         result = handle_filter_command(
             ["/error/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -86,7 +85,6 @@ class TestHandleFilterCommand:
         """-/pattern/ adds exclude filter."""
         result = handle_filter_command(
             ["-/noise/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -104,7 +102,6 @@ class TestHandleFilterCommand:
         # First set an include
         handle_filter_command(
             ["/error/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -113,7 +110,6 @@ class TestHandleFilterCommand:
         # Then add OR pattern
         result = handle_filter_command(
             ["+/warning/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -129,7 +125,6 @@ class TestHandleFilterCommand:
         """&/pattern/ adds AND filter."""
         result = handle_filter_command(
             ["&/critical/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -146,7 +141,6 @@ class TestHandleFilterCommand:
         """/pattern/c enables case-sensitive matching."""
         result = handle_filter_command(
             ["/Error/c"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -165,7 +159,6 @@ class TestHandleFilterCommand:
         """field=value sets field filter."""
         result = handle_filter_command(
             ["app=myapp"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -186,7 +179,6 @@ class TestHandleFilterCommand:
         mock_tailer.format = LogFormat.TEXT
         result = handle_filter_command(
             ["app=myapp"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -210,7 +202,6 @@ class TestHandleFilterCommand:
         mock_state.field_filter.add("app", "test")
         handle_filter_command(
             ["/error/"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -220,7 +211,6 @@ class TestHandleFilterCommand:
         # Now clear
         result = handle_filter_command(
             ["clear"],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -240,7 +230,6 @@ class TestHandleFilterCommand:
         """No args shows current filter status."""
         result = handle_filter_command(
             [],
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -279,7 +268,6 @@ class TestHandleClearCommand:
         assert mock_state.field_filter.is_active() is True
 
         result = handle_clear_command(
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,
@@ -295,7 +283,6 @@ class TestHandleClearCommand:
     ) -> None:
         """handle_clear_command should update tailer's field filter."""
         result = handle_clear_command(
-
             status=mock_status,
             state=mock_state,
             tailer=mock_tailer,

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -29,7 +29,6 @@ from pgtail_py.notify import (
     _make_tag,
 )
 
-
 # ===================================================================
 # Tier 1: Pure logic tests — all platforms, no COM
 # ===================================================================
@@ -241,7 +240,7 @@ class TestHSTRING:
     def test_empty_string(self):
         from pgtail_py._winrt import hstring
 
-        with hstring("") as hs:
+        with hstring("") as _hs:
             # Empty HSTRING may be None, which is valid
             pass  # Just ensure no exception
 
@@ -543,9 +542,15 @@ class TestNotificationManagerIntegration:
         mock_notifier.is_available.return_value = True
 
         config = NotificationConfig(enabled=True)
-        config.add_rule(NotificationRule.level_rule({
-            LogLevel.ERROR, LogLevel.FATAL, LogLevel.PANIC,
-        }))
+        config.add_rule(
+            NotificationRule.level_rule(
+                {
+                    LogLevel.ERROR,
+                    LogLevel.FATAL,
+                    LogLevel.PANIC,
+                }
+            )
+        )
 
         manager = NotificationManager(notifier=mock_notifier, config=config)
         return manager, mock_notifier
@@ -639,9 +644,7 @@ class TestNoOpNotifier:
 
     def test_send_new_params(self):
         n = NoOpNotifier()
-        result = n.send(
-            "title", "body", severity="error", tag="test", suppress_popup=True
-        )
+        result = n.send("title", "body", severity="error", tag="test", suppress_popup=True)
         assert result is False
 
     def test_dismiss(self):
@@ -691,9 +694,9 @@ def com_recorder():
 @pytest.fixture
 def mock_winrt_notifier(com_recorder):
     """Create a WindowsNotifier with the _winrt module mocked."""
+    import contextlib
     import ctypes
     from contextlib import contextmanager
-    from unittest.mock import MagicMock
 
     recorder = com_recorder
 
@@ -712,7 +715,7 @@ def mock_winrt_notifier(com_recorder):
 
     def fake_qi(ptr, iid):
         result = ctypes.c_void_p(recorder.next_ptr())
-        recorder.calls.append(("qi", ptr.value if hasattr(ptr, 'value') else ptr, repr(iid)))
+        recorder.calls.append(("qi", ptr.value if hasattr(ptr, "value") else ptr, repr(iid)))
         return result
 
     def fake_vcall(ptr, slot, restype, *args_spec):
@@ -721,21 +724,19 @@ def mock_winrt_notifier(com_recorder):
         for i in range(0, len(args_spec), 2):
             val = args_spec[i + 1] if i + 1 < len(args_spec) else None
             # Dereference pointer outputs so the caller gets a valid pointer back
-            if hasattr(val, 'contents') or (hasattr(val, '_type_') and hasattr(val, 'value')):
+            if hasattr(val, "contents") or (hasattr(val, "_type_") and hasattr(val, "value")):
                 pass
             values.append(val)
-        ptr_val = ptr.value if hasattr(ptr, 'value') else ptr
+        ptr_val = ptr.value if hasattr(ptr, "value") else ptr
         recorder.vcalls.append(("vcall", ptr_val, slot, *values))
         # For calls that output a pointer (via ctypes.byref), set a fake value
         for i in range(0, len(args_spec), 2):
             argtype = args_spec[i]
             if i + 1 < len(args_spec):
                 argval = args_spec[i + 1]
-                if hasattr(argtype, '_type_') and argtype._type_ == ctypes.c_void_p:
-                    try:
+                if hasattr(argtype, "_type_") and argtype._type_ == ctypes.c_void_p:
+                    with contextlib.suppress(AttributeError, TypeError):
                         argval.value = recorder.next_ptr()
-                    except (AttributeError, TypeError):
-                        pass
         return 0  # S_OK
 
     def fake_vcall_check(ptr, slot, *args_spec):
@@ -769,9 +770,9 @@ def mock_winrt_notifier(com_recorder):
 
     from pgtail_py.notifier_windows import WindowsNotifier
 
-    with patch.multiple("pgtail_py.notifier_windows", **{
-        k.split(".")[-1]: v for k, v in patches.items()
-    }):
+    with patch.multiple(
+        "pgtail_py.notifier_windows", **{k.split(".")[-1]: v for k, v in patches.items()}
+    ):
         notifier = WindowsNotifier()
         yield notifier, recorder
 
@@ -824,7 +825,9 @@ class TestMockSeamSend:
         qi_calls = [c for c in recorder.calls if c[0] == "qi"]
         iids_queried = [c[2] for c in qi_calls]
         n2_iid = repr(
-            __import__("pgtail_py._winrt", fromlist=["IID_IToastNotification2"]).IID_IToastNotification2
+            __import__(
+                "pgtail_py._winrt", fromlist=["IID_IToastNotification2"]
+            ).IID_IToastNotification2
         )
         assert n2_iid in iids_queried
 
@@ -872,7 +875,9 @@ class TestMockSeamSend:
 
         # No QI to IToastNotification4 for info
         n4_iid = repr(
-            __import__("pgtail_py._winrt", fromlist=["IID_IToastNotification4"]).IID_IToastNotification4
+            __import__(
+                "pgtail_py._winrt", fromlist=["IID_IToastNotification4"]
+            ).IID_IToastNotification4
         )
         qi_calls = [c for c in recorder.calls if c[0] == "qi" and c[2] == n4_iid]
         assert len(qi_calls) == 0
@@ -882,7 +887,9 @@ class TestMockSeamSend:
         notifier.send("Title", "Body", severity="warning")
 
         n4_iid = repr(
-            __import__("pgtail_py._winrt", fromlist=["IID_IToastNotification4"]).IID_IToastNotification4
+            __import__(
+                "pgtail_py._winrt", fromlist=["IID_IToastNotification4"]
+            ).IID_IToastNotification4
         )
         qi_calls = [c for c in recorder.calls if c[0] == "qi" and c[2] == n4_iid]
         assert len(qi_calls) == 0
@@ -909,7 +916,9 @@ class TestMockSeamDismiss:
 
         # QI to IToastNotificationManagerStatics2
         n2_iid = repr(
-            __import__("pgtail_py._winrt", fromlist=["IID_IToastNotificationManagerStatics2"]).IID_IToastNotificationManagerStatics2
+            __import__(
+                "pgtail_py._winrt", fromlist=["IID_IToastNotificationManagerStatics2"]
+            ).IID_IToastNotificationManagerStatics2
         )
         qi_calls = [c for c in recorder.calls if c[0] == "qi" and c[2] == n2_iid]
         assert len(qi_calls) >= 1
@@ -935,8 +944,6 @@ class TestMockSeamFailureTracking:
         notifier, recorder = mock_winrt_notifier
 
         # Make vcall_check raise a transient error for Show()
-        original_vcall_check = notifier.__class__.send
-
         with patch("pgtail_py.notifier_windows.vcall_check", side_effect=OSError("0x80070001")):
             result = notifier.send("Title", "Body")
 

--- a/tests/test_tail_completion_data.py
+++ b/tests/test_tail_completion_data.py
@@ -100,7 +100,6 @@ class TestBooleanFlags:
         assert TAIL_COMPLETION_DATA["export"].flags["--highlighted"] is None
 
 
-
 # ---------------------------------------------------------------------------
 # 3. Value-taking flags map to CompletionSpec instances
 # ---------------------------------------------------------------------------

--- a/tests/test_tail_log.py
+++ b/tests/test_tail_log.py
@@ -377,3 +377,101 @@ class TestMouseClickSelection:
             # (actual line selection is Textual's responsibility)
             # We verify the click was received and processed
             assert log.line_count == 2
+
+
+class TestRenderLineCache:
+    """Tests for the _render_line_cache in TailLog._render_line_strip."""
+
+    @pytest.mark.asyncio
+    async def test_cache_populated_after_render(self) -> None:
+        """Rendered lines are stored in the cache for reuse."""
+        from textual.app import App, ComposeResult
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TailLog(id="log")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            log = app.query_one("#log", TailLog)
+            log.write_line("[bold]hello[/bold] world")
+            await pilot.pause()
+
+            # After rendering, line 0 should be cached
+            assert 0 in log._render_line_cache
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_same_strip(self) -> None:
+        """A second render of the same line returns the cached Strip."""
+        from textual.app import App, ComposeResult
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TailLog(id="log")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            log = app.query_one("#log", TailLog)
+            log.write_line("[green]cached[/green]")
+            await pilot.pause()
+
+            cached_strip = log._render_line_cache.get(0)
+            assert cached_strip is not None
+
+            # Render again — should return the exact same object
+            from rich.style import Style
+
+            result = log._render_line_strip(0, Style())
+            assert result is cached_strip
+
+    @pytest.mark.asyncio
+    async def test_cache_cleared_on_clear(self) -> None:
+        """Calling clear() empties the render cache."""
+        from textual.app import App, ComposeResult
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TailLog(id="log")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            log = app.query_one("#log", TailLog)
+            log.write_line("[red]line[/red]")
+            await pilot.pause()
+
+            assert len(log._render_line_cache) > 0
+
+            log.clear()
+            assert len(log._render_line_cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_bypassed_during_selection(self) -> None:
+        """Cache is not used when a text selection is active."""
+        from textual.app import App, ComposeResult
+
+        class TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield TailLog(id="log")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            log = app.query_one("#log", TailLog)
+            log.write_line("[blue]selectable[/blue]")
+            await pilot.pause()
+
+            # Populate cache
+            assert 0 in log._render_line_cache
+            cached_strip = log._render_line_cache.get(0)
+
+            # Activate a selection — cache should be bypassed
+            log.focus()
+            await pilot.pause()
+            await pilot.press("ctrl+a")
+            await pilot.pause()
+
+            from rich.style import Style
+
+            result = log._render_line_strip(0, Style())
+            # With selection active, result should be freshly rendered
+            # (not the same object as the cached clean strip)
+            assert result is not cached_strip

--- a/tests/test_tail_textual.py
+++ b/tests/test_tail_textual.py
@@ -891,7 +891,7 @@ class TestAsyncRebuildLog:
             mock_tailer.file_permission_denied = False
             mock_tailer_class.return_value = mock_tailer
 
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 log_widget = app.query_one("#log", TailLog)
 
                 # Simulate being mid-rebuild
@@ -1036,7 +1036,7 @@ class TestHighlightFeedbackCorrectness:
             mock_tailer.file_permission_denied = False
             mock_tailer_class.return_value = mock_tailer
 
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 log_widget = app.query_one("#log", TailLog)
 
                 rebuild_calls: list[dict] = []
@@ -1091,7 +1091,7 @@ class TestHighlightFeedbackCorrectness:
             mock_tailer.file_permission_denied = False
             mock_tailer_class.return_value = mock_tailer
 
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 log_widget = app.query_one("#log", TailLog)
 
                 # First disable a highlighter so we can re-enable it
@@ -1146,7 +1146,7 @@ class TestHighlightFeedbackCorrectness:
             mock_tailer.file_permission_denied = False
             mock_tailer_class.return_value = mock_tailer
 
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 log_widget = app.query_one("#log", TailLog)
 
                 rebuild_calls: list[dict] = []


### PR DESCRIPTION
## Summary
- **Re-enable render cache**: `TailLog._render_line_strip()` was bypassing the inherited `_render_line_cache` (LRU, 1024 slots), re-parsing Rich markup via `Text.from_markup()` on every visible line every frame. Cache now serves unchanged lines instantly during scrolling, resizing, and repaints.
- **Cache strategy**: read/write when no text selection is active; bypass during selection (styling varies per-render). Invalidation is handled by inherited `clear()`, `notify_style_update()`, `selection_updated()`, and `_prune_max_lines()`.
- **Fix all ruff lint warnings**: unused variables, unsorted imports, `contextlib.suppress` preference across `test_notifier.py`, `test_tail_textual.py`, `test_cli_tail_filters.py`, `test_tail_completion_data.py`.

## Test plan
- [x] `test_cache_populated_after_render` — rendered lines enter the cache
- [x] `test_cache_hit_returns_same_strip` — second render returns the exact cached object
- [x] `test_cache_cleared_on_clear` — `clear()` empties the cache
- [x] `test_cache_bypassed_during_selection` — active selection forces fresh render
- [x] All 1696 tests pass, ruff format + check clean

Fixes: #37