### PR TITLE
fix(tail): render log content as Rich Text to avoid markup crashes

### DIFF
--- a/pgtail_py/cli_highlight.py
+++ b/pgtail_py/cli_highlight.py
@@ -19,6 +19,7 @@ from difflib import get_close_matches
 from typing import TYPE_CHECKING, Any, cast
 
 from prompt_toolkit.formatted_text import FormattedText
+from rich.text import Text
 
 from pgtail_py.highlighter_registry import get_registry
 from pgtail_py.highlighting_config import (
@@ -42,7 +43,7 @@ if TYPE_CHECKING:
 # Cache for highlighted preview samples
 # Key: (theme_name, highlighting_enabled, disabled_highlighters_tuple)
 # Value: dict mapping sample index to highlighted output
-_preview_sample_cache: dict[tuple[str, bool, tuple[str, ...]], dict[int, str]] = {}
+_preview_sample_cache: dict[tuple[str, bool, tuple[str, ...]], dict[int, Text]] = {}
 
 
 # =============================================================================
@@ -231,21 +232,27 @@ def format_highlight_list(config: HighlightingConfig) -> FormattedText:
     return FormattedText(result)
 
 
-def format_highlight_list_rich(config: HighlightingConfig) -> str:
+def format_highlight_list_rich(config: HighlightingConfig) -> Text:
     """Format the list of all highlighters with their status for Rich/Textual.
 
     Args:
         config: Current highlighting configuration.
 
     Returns:
-        Rich markup string for display.
+        Rich Text for display.
     """
-    lines: list[str] = []
+    result = Text()
+
+    def append_line(text: str = "", style: str | None = None) -> None:
+        result.append(text, style=style)
+        result.append("\n")
 
     # Show global status
     global_status = "enabled" if config.enabled else "disabled"
-    global_color = "green" if config.enabled else "red"
-    lines.append(f"Semantic Highlighting: [{global_color}]{global_status}[/]\n")
+    global_style = "green" if config.enabled else "red"
+    result.append("Semantic Highlighting: ")
+    result.append(global_status, style=global_style)
+    result.append("\n\n")
 
     # Group highlighters by category
     categories: dict[str, list[str]] = {}
@@ -275,38 +282,40 @@ def format_highlight_list_rich(config: HighlightingConfig) -> str:
         names = sorted(categories[category])
 
         # Category header
-        lines.append(f"[bold]{category.title()}[/]")
+        append_line(category.title(), style="bold")
 
         for name in names:
             _, description = HIGHLIGHTER_METADATA[name]
             enabled = config.is_highlighter_enabled(name)
             status_text = "on" if enabled else "off"
-            status_color = "green" if enabled else "red"
+            status_style = "green" if enabled else "red"
 
-            # Escape brackets in description
-            desc = description.replace("[", "\\[")
-            lines.append(
-                f"  \\[[{status_color}]{status_text:3}[/]\\] [cyan]{name:20}[/] [dim]{desc}[/]"
-            )
+            result.append("  [")
+            result.append(f"{status_text:3}", style=status_style)
+            result.append("] ")
+            result.append(f"{name:20}", style="cyan")
+            result.append(f" {description}", style="dim")
+            result.append("\n")
 
-        lines.append("")
+        result.append("\n")
 
     # Show custom highlighters if any
     if config.custom_highlighters:
-        lines.append("[bold]Custom[/]")
+        append_line("Custom", style="bold")
         for custom in config.custom_highlighters:
             enabled = custom.enabled
             status_text = "on" if enabled else "off"
-            status_color = "green" if enabled else "red"
-            pattern = custom.pattern.replace("[", "\\[")
+            status_style = "green" if enabled else "red"
 
-            lines.append(
-                f"  \\[[{status_color}]{status_text:3}[/]\\] "
-                f"[cyan]{custom.name:20}[/] [dim]Pattern: {pattern}[/]"
-            )
-        lines.append("")
+            result.append("  [")
+            result.append(f"{status_text:3}", style=status_style)
+            result.append("] ")
+            result.append(f"{custom.name:20}", style="cyan")
+            result.append(f" Pattern: {custom.pattern}", style="dim")
+            result.append("\n")
+        result.append("\n")
 
-    return "\n".join(lines)
+    return result
 
 
 # =============================================================================
@@ -1128,7 +1137,7 @@ def _get_cached_preview_sample(
     chain: object,
     theme: Theme,
     highlighting_enabled: bool,
-) -> str:
+) -> Text:
     """Get a highlighted preview sample, using cache if available.
 
     Args:
@@ -1140,7 +1149,7 @@ def _get_cached_preview_sample(
         highlighting_enabled: Whether highlighting is enabled.
 
     Returns:
-        Highlighted or escaped sample string.
+        Highlighted sample Text.
     """
     global _preview_sample_cache
 
@@ -1148,20 +1157,18 @@ def _get_cached_preview_sample(
     if cache_key in _preview_sample_cache:
         cached_samples = _preview_sample_cache[cache_key]
         if sample_index in cached_samples:
-            return cached_samples[sample_index]
+            return cached_samples[sample_index].copy()
 
     # Not in cache - compute highlighted result
-    highlighted: str
     if highlighting_enabled:
-        highlighted = cast(str, chain.apply_rich(sample, theme))  # type: ignore[union-attr]
+        highlighted = chain.apply_rich_text(sample, theme)  # type: ignore[union-attr]
     else:
-        # Escape brackets for display but no highlighting
-        highlighted = sample.replace("[", "\\[")
+        highlighted = Text(sample)
 
     # Store in cache
     if cache_key not in _preview_sample_cache:
         _preview_sample_cache[cache_key] = {}
-    _preview_sample_cache[cache_key][sample_index] = highlighted
+    _preview_sample_cache[cache_key][sample_index] = highlighted.copy()
 
     return highlighted
 
@@ -1178,7 +1185,7 @@ def clear_preview_cache() -> None:
 def format_preview_rich(
     config: HighlightingConfig,
     theme: Theme | None = None,
-) -> str:
+) -> Text:
     """Format preview output with highlighted samples for Rich/Textual.
 
     Uses a cache for highlighted samples to improve performance (FR-161).
@@ -1189,7 +1196,7 @@ def format_preview_rich(
         theme: Current theme for style lookups. If None, uses default dark theme.
 
     Returns:
-        Rich markup string for display.
+        Rich Text for display.
     """
     from pgtail_py.tail_rich import get_highlighter_chain
     from pgtail_py.theme import ThemeManager
@@ -1202,17 +1209,23 @@ def format_preview_rich(
     # Ensure theme is available (should always succeed with ThemeManager)
     assert theme is not None, "No theme available"
 
-    lines: list[str] = []
+    result = Text()
+
+    def append_line(text: str = "", style: str | None = None) -> None:
+        result.append(text, style=style)
+        result.append("\n")
 
     # Header
     global_status = "enabled" if config.enabled else "disabled"
-    global_color = "green" if config.enabled else "red"
-    lines.append(f"[bold cyan]Highlight Preview[/] ([{global_color}]{global_status}[/])")
-    lines.append("")
+    global_style = "green" if config.enabled else "red"
+    result.append("Highlight Preview", style="bold cyan")
+    result.append(" (")
+    result.append(global_status, style=global_style)
+    result.append(")\n\n")
 
     if not config.enabled:
-        lines.append("[dim]Highlighting is disabled. Run 'highlight on' to enable.[/]")
-        lines.append("")
+        append_line("Highlighting is disabled. Run 'highlight on' to enable.", style="dim")
+        result.append("\n")
 
     # Get the highlighter chain (ensures highlighters are registered)
     chain = get_highlighter_chain(config)
@@ -1298,7 +1311,7 @@ def format_preview_rich(
         if not samples:
             continue
 
-        lines.append(f"[bold]{category}[/]")
+        append_line(category, style="bold")
 
         for idx, highlighter_names, sample, desc in samples:
             # Check if any of the relevant highlighters are disabled
@@ -1312,33 +1325,37 @@ def format_preview_rich(
             )
 
             # Show the sample with description
-            lines.append(f"  [dim]{desc}[/]")
+            result.append("  ")
+            append_line(desc, style="dim")
             if disabled_for_sample:
                 disabled_list = ", ".join(disabled_for_sample)
-                lines.append(f"  [yellow]⚠ Disabled:[/] [dim]{disabled_list}[/]")
-            lines.append(f"  {highlighted}")
-            lines.append("")
+                result.append("  ")
+                result.append("Disabled: ", style="yellow")
+                append_line(disabled_list, style="dim")
+            result.append("  ")
+            result.append(highlighted)
+            result.append("\n\n")
 
     # Show disabled highlighters summary
     if disabled_highlighters:
-        lines.append("[bold yellow]Disabled Highlighters[/]")
+        append_line("Disabled Highlighters", style="bold yellow")
         for name in sorted(disabled_highlighters):
-            lines.append(f"  [dim]• {name}[/]")
-        lines.append("")
-        lines.append("[dim]Use 'highlight enable <name>' to enable disabled highlighters.[/]")
+            append_line(f"  - {name}", style="dim")
+        result.append("\n")
+        append_line("Use 'highlight enable <name>' to enable disabled highlighters.", style="dim")
 
     # Show custom highlighters
     if config.custom_highlighters:
-        lines.append("")
-        lines.append("[bold]Custom Highlighters[/]")
+        result.append("\n")
+        append_line("Custom Highlighters", style="bold")
         for custom in config.custom_highlighters:
-            status_color = "green" if custom.enabled else "red"
-            pattern = custom.pattern.replace("[", "\\[")
-            lines.append(
-                f"  [{status_color}]{custom.name}[/]: {pattern} [dim](style: {custom.style})[/]"
-            )
+            status_style = "green" if custom.enabled else "red"
+            result.append("  ")
+            result.append(custom.name, style=status_style)
+            result.append(f": {custom.pattern} ")
+            append_line(f"(style: {custom.style})", style="dim")
 
-    return "\n".join(lines)
+    return result
 
 
 def format_preview_text(
@@ -1516,7 +1533,7 @@ def handle_highlight_preview(
     config: HighlightingConfig,
     theme: Theme | None = None,
     use_rich: bool = False,
-) -> tuple[bool, str | FormattedText]:
+) -> tuple[bool, Text | FormattedText]:
     """Handle 'highlight preview' command.
 
     Shows sample log lines with current highlighting settings applied.
@@ -1525,7 +1542,7 @@ def handle_highlight_preview(
     Args:
         config: Current highlighting configuration.
         theme: Current theme for style lookups. If None, uses default theme.
-        use_rich: If True, return Rich markup string; if False, return FormattedText.
+        use_rich: If True, return Rich Text; if False, return FormattedText.
 
     Returns:
         Tuple of (success, formatted_output).

--- a/pgtail_py/cli_tail_display.py
+++ b/pgtail_py/cli_tail_display.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rich.text import Text
+
 if TYPE_CHECKING:
     from pgtail_py.cli import AppState
     from pgtail_py.tail_log import TailLog
@@ -36,11 +38,11 @@ def handle_errors_command(
     by_code = error_stats.get_by_code()
 
     if log_widget is not None:
-        log_widget.write_line(
+        log_widget.write_markup_line(
             f"[bold cyan]Error Statistics[/bold cyan]  Total: [magenta]{total}[/magenta]"
         )
         if by_level:
-            log_widget.write_line("[dim]  By Level:[/dim]")
+            log_widget.write_markup_line("[dim]  By Level:[/dim]")
             for level, count in sorted(by_level.items(), key=lambda x: x[1], reverse=True):
                 color = {
                     "PANIC": "bold red",
@@ -48,13 +50,13 @@ def handle_errors_command(
                     "ERROR": "yellow",
                     "WARNING": "cyan",
                 }.get(level.name, "white")
-                log_widget.write_line(
+                log_widget.write_markup_line(
                     f"    [{color}]{level.name}[/{color}]: [magenta]{count}[/magenta]"
                 )
         if by_code:
-            log_widget.write_line("[dim]  By SQLSTATE:[/dim]")
+            log_widget.write_markup_line("[dim]  By SQLSTATE:[/dim]")
             for code, count in sorted(by_code.items(), key=lambda x: x[1], reverse=True)[:10]:
-                log_widget.write_line(f"    [cyan]{code}[/cyan]: [magenta]{count}[/magenta]")
+                log_widget.write_markup_line(f"    [cyan]{code}[/cyan]: [magenta]{count}[/magenta]")
     return True
 
 
@@ -79,20 +81,20 @@ def handle_connections_command(
     by_user = conn_stats.get_by_user()
 
     if log_widget is not None:
-        log_widget.write_line("[bold cyan]Connection Statistics[/bold cyan]")
-        log_widget.write_line(
+        log_widget.write_markup_line("[bold cyan]Connection Statistics[/bold cyan]")
+        log_widget.write_markup_line(
             f"  Active: [magenta]{conn_stats.active_count()}[/magenta]  "
             f"Connects: [green]{conn_stats.connect_count}[/green]  "
             f"Disconnects: [red]{conn_stats.disconnect_count}[/red]"
         )
         if by_db:
-            log_widget.write_line("[dim]  By Database:[/dim]")
+            log_widget.write_markup_line("[dim]  By Database:[/dim]")
             for db, count in sorted(by_db.items(), key=lambda x: x[1], reverse=True)[:5]:
-                log_widget.write_line(f"    [cyan]{db}[/cyan]: [magenta]{count}[/magenta]")
+                log_widget.write_markup_line(f"    [cyan]{db}[/cyan]: [magenta]{count}[/magenta]")
         if by_user:
-            log_widget.write_line("[dim]  By User:[/dim]")
+            log_widget.write_markup_line("[dim]  By User:[/dim]")
             for user, count in sorted(by_user.items(), key=lambda x: x[1], reverse=True)[:5]:
-                log_widget.write_line(f"    [cyan]{user}[/cyan]: [magenta]{count}[/magenta]")
+                log_widget.write_markup_line(f"    [cyan]{user}[/cyan]: [magenta]{count}[/magenta]")
     return True
 
 
@@ -139,9 +141,7 @@ def handle_highlight_command(
     if not args or (args and args[0].lower() == "list"):
         if log_widget is not None:
             output = format_highlight_list_rich(config)
-            for line in output.split("\n"):
-                if line:  # Skip empty lines
-                    log_widget.write_line(line)
+            log_widget.write_text_lines(output.split("\n"))
         return True
 
     subcommand = args[0].lower()
@@ -152,7 +152,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'off' subcommand - disable all highlighting globally
@@ -161,7 +161,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "yellow" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'enable' subcommand
@@ -169,7 +169,7 @@ def handle_highlight_command(
         if len(args) < 2:
             msg = "Usage: highlight enable <name>"
             if log_widget is not None:
-                log_widget.write_line(f"[red]{msg}[/red]")
+                log_widget.write_text_line(Text(msg, style="red"))
             return True
 
         name = args[1]
@@ -177,7 +177,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'disable' subcommand
@@ -185,7 +185,7 @@ def handle_highlight_command(
         if len(args) < 2:
             msg = "Usage: highlight disable <name>"
             if log_widget is not None:
-                log_widget.write_line(f"[red]{msg}[/red]")
+                log_widget.write_text_line(Text(msg, style="red"))
             return True
 
         name = args[1]
@@ -193,7 +193,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'add' subcommand
@@ -202,7 +202,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'remove' subcommand
@@ -210,7 +210,7 @@ def handle_highlight_command(
         if len(args) < 2:
             msg = "Usage: highlight remove <name>"
             if log_widget is not None:
-                log_widget.write_line(f"[red]{msg}[/red]")
+                log_widget.write_text_line(Text(msg, style="red"))
             return True
 
         name = args[1]
@@ -218,7 +218,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'export' subcommand
@@ -231,12 +231,12 @@ def handle_highlight_command(
                 if message.startswith("#") or message.startswith("["):
                     # TOML output - show in dim
                     for line in message.split("\n"):
-                        log_widget.write_line(f"[dim]{line}[/dim]")
+                        log_widget.write_text_line(Text(line, style="dim"))
                 else:
                     # File export confirmation - show in green
-                    log_widget.write_line(f"[green]{message}[/green]")
+                    log_widget.write_text_line(Text(message, style="green"))
             else:
-                log_widget.write_line(f"[red]{message}[/red]")
+                log_widget.write_text_line(Text(message, style="red"))
         return True
 
     # Handle 'import' subcommand
@@ -245,7 +245,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Handle 'preview' subcommand
@@ -254,9 +254,7 @@ def handle_highlight_command(
 
         if log_widget is not None:
             success, output = handle_highlight_preview(config, use_rich=True)
-            # output is a Rich markup string
-            for line in str(output).split("\n"):
-                log_widget.write_line(line)
+            log_widget.write_text_lines(output.split("\n"))
         return True
 
     # Handle 'reset' subcommand
@@ -267,13 +265,13 @@ def handle_highlight_command(
 
         if log_widget is not None:
             color = "green" if success else "red"
-            log_widget.write_line(f"[{color}]{message}[/{color}]")
+            log_widget.write_text_line(Text(message, style=color))
         return True
 
     # Unknown subcommand
     msg = f"Unknown subcommand: {subcommand}. Use: list, on, off, enable, disable, add, remove, export, import, preview, reset"
     if log_widget is not None:
-        log_widget.write_line(f"[red]{msg}[/red]")
+        log_widget.write_text_line(Text(msg, style="red"))
     return True
 
 
@@ -305,11 +303,11 @@ def handle_set_command(
     # No args - show usage and available settings
     if not args:
         if log_widget is not None:
-            log_widget.write_line("[dim]Usage: set <key> [value][/dim]")
-            log_widget.write_line("")
-            log_widget.write_line("[bold]Available settings:[/bold]")
+            log_widget.write_markup_line("[dim]Usage: set <key> [value][/dim]")
+            log_widget.write_markup_line("")
+            log_widget.write_markup_line("[bold]Available settings:[/bold]")
             for key in SETTINGS_SCHEMA:
-                log_widget.write_line(f"  [cyan]{key}[/cyan]")
+                log_widget.write_markup_line(f"  [cyan]{key}[/cyan]")
         return True
 
     key = args[0]
@@ -318,7 +316,7 @@ def handle_set_command(
     if not validate_key(key):
         msg = f"Unknown setting: {key}"
         if log_widget is not None:
-            log_widget.write_line(f"[red]{msg}[/red]")
+            log_widget.write_markup_line(f"[red]{msg}[/red]")
         return True
 
     # No value - display current value
@@ -329,7 +327,7 @@ def handle_set_command(
             msg = f"[cyan]{key}[/cyan] = [magenta]{current!r}[/magenta]"
             if current != default:
                 msg += f" [dim](default: {default!r})[/dim]"
-            log_widget.write_line(msg)
+            log_widget.write_markup_line(msg)
         return True
 
     # Parse and validate value
@@ -339,7 +337,7 @@ def handle_set_command(
     except ValueError as e:
         msg = f"Invalid value for {key}: {e}"
         if log_widget is not None:
-            log_widget.write_line(f"[red]{msg}[/red]")
+            log_widget.write_markup_line(f"[red]{msg}[/red]")
         return True
 
     # Validate the value using schema validator
@@ -349,14 +347,14 @@ def handle_set_command(
     except ValueError as e:
         msg = f"Invalid value for {key}: {e}"
         if log_widget is not None:
-            log_widget.write_line(f"[red]{msg}[/red]")
+            log_widget.write_markup_line(f"[red]{msg}[/red]")
         return True
 
     # Save to config file
     if not save_config(key, validated, warn_func=warn):
         msg = "Failed to save configuration"
         if log_widget is not None:
-            log_widget.write_line(f"[red]{msg}[/red]")
+            log_widget.write_markup_line(f"[red]{msg}[/red]")
         return True
 
     # Update in-memory config
@@ -367,7 +365,7 @@ def handle_set_command(
 
     # Provide feedback
     if log_widget is not None:
-        log_widget.write_line(
+        log_widget.write_markup_line(
             f"[green]Set[/green] [cyan]{key}[/cyan] = [magenta]{validated!r}[/magenta]"
         )
 

--- a/pgtail_py/cli_tail_filters.py
+++ b/pgtail_py/cli_tail_filters.py
@@ -124,20 +124,20 @@ def handle_filter_command(
 
         if log_widget is not None:
             if not has_regex and not has_field:
-                log_widget.write_line("[dim]No filters active[/]")
+                log_widget.write_markup_line("[dim]No filters active[/]")
             else:
                 if has_regex:
                     for f in state.regex_state.includes:
                         cs = "c" if f.case_sensitive else ""
-                        log_widget.write_line(f"[dim]include:[/] [cyan]/{f.pattern}/{cs}[/]")
+                        log_widget.write_markup_line(f"[dim]include:[/] [cyan]/{f.pattern}/{cs}[/]")
                     for f in state.regex_state.excludes:
                         cs = "c" if f.case_sensitive else ""
-                        log_widget.write_line(f"[dim]exclude:[/] [yellow]-/{f.pattern}/{cs}[/]")
+                        log_widget.write_markup_line(f"[dim]exclude:[/] [yellow]-/{f.pattern}/{cs}[/]")
                     for f in state.regex_state.ands:
                         cs = "c" if f.case_sensitive else ""
-                        log_widget.write_line(f"[dim]and:[/] [green]&/{f.pattern}/{cs}[/]")
+                        log_widget.write_markup_line(f"[dim]and:[/] [green]&/{f.pattern}/{cs}[/]")
                 if has_field:
-                    log_widget.write_line(f"[dim]{state.field_filter.format_status()}[/]")
+                    log_widget.write_markup_line(f"[dim]{state.field_filter.format_status()}[/]")
         return True
 
     arg = args[0]
@@ -150,14 +150,14 @@ def handle_filter_command(
         tailer.update_field_filter(state.field_filter)
         status.set_regex_filter(None)
         if log_widget is not None:
-            log_widget.write_line("[bold green]✓[/] All filters cleared")
+            log_widget.write_markup_line("[bold green]✓[/] All filters cleared")
         return True
 
     # Check if this is a field filter (field=value syntax)
     if _is_field_filter_arg(arg):
         # Warn about text format
         if tailer.format == LogFormat.TEXT and log_widget is not None:
-            log_widget.write_line(
+            log_widget.write_markup_line(
                 "[yellow]Warning:[/] Field filtering only works for CSV/JSON logs"
             )
 
@@ -172,12 +172,12 @@ def handle_filter_command(
                     tailer.update_field_filter(state.field_filter)
                     resolved = resolve_field_name(field_name)
                     if log_widget is not None:
-                        log_widget.write_line(
+                        log_widget.write_markup_line(
                             f"[bold green]✓[/] Field filter: [cyan]{resolved}={value}[/]"
                         )
                 except ValueError as e:
                     if log_widget is not None:
-                        log_widget.write_line(f"[bold red]✗[/] Error: {e}")
+                        log_widget.write_markup_line(f"[bold red]✗[/] Error: {e}")
         return True
 
     # Determine filter type based on prefix
@@ -195,8 +195,8 @@ def handle_filter_command(
         pattern_arg = arg
     else:
         if log_widget is not None:
-            log_widget.write_line(f"[bold red]✗[/] Invalid filter syntax: {arg}")
-            log_widget.write_line(
+            log_widget.write_markup_line(f"[bold red]✗[/] Invalid filter syntax: {arg}")
+            log_widget.write_markup_line(
                 "[dim]Use /pattern/, -/pattern/, +/pattern/, &/pattern/, or field=value[/]"
             )
         return True
@@ -206,7 +206,7 @@ def handle_filter_command(
         pattern, case_sensitive = parse_filter_arg(pattern_arg)
     except ValueError as e:
         if log_widget is not None:
-            log_widget.write_line(f"[bold red]✗[/] Error: {e}")
+            log_widget.write_markup_line(f"[bold red]✗[/] Error: {e}")
         return True
 
     # Create and apply the filter
@@ -244,13 +244,13 @@ def handle_filter_command(
                 FilterType.AND: "and",
             }.get(filter_type, "filter")
             cs = "c" if case_sensitive else ""
-            log_widget.write_line(f"[bold green]✓[/] Filter {type_str}: [cyan]/{pattern}/{cs}[/]")
+            log_widget.write_markup_line(f"[bold green]✓[/] Filter {type_str}: [cyan]/{pattern}/{cs}[/]")
 
         # Note: Textual mode rebuilds log in TailApp._handle_command() after this returns
 
     except Exception as e:
         if log_widget is not None:
-            log_widget.write_line(f"[bold red]✗[/] Invalid pattern: {e}")
+            log_widget.write_markup_line(f"[bold red]✗[/] Invalid pattern: {e}")
 
     return True
 

--- a/pgtail_py/cli_tail_filters.py
+++ b/pgtail_py/cli_tail_filters.py
@@ -132,7 +132,9 @@ def handle_filter_command(
                         log_widget.write_markup_line(f"[dim]include:[/] [cyan]/{f.pattern}/{cs}[/]")
                     for f in state.regex_state.excludes:
                         cs = "c" if f.case_sensitive else ""
-                        log_widget.write_markup_line(f"[dim]exclude:[/] [yellow]-/{f.pattern}/{cs}[/]")
+                        log_widget.write_markup_line(
+                            f"[dim]exclude:[/] [yellow]-/{f.pattern}/{cs}[/]"
+                        )
                     for f in state.regex_state.ands:
                         cs = "c" if f.case_sensitive else ""
                         log_widget.write_markup_line(f"[dim]and:[/] [green]&/{f.pattern}/{cs}[/]")
@@ -244,7 +246,9 @@ def handle_filter_command(
                 FilterType.AND: "and",
             }.get(filter_type, "filter")
             cs = "c" if case_sensitive else ""
-            log_widget.write_markup_line(f"[bold green]✓[/] Filter {type_str}: [cyan]/{pattern}/{cs}[/]")
+            log_widget.write_markup_line(
+                f"[bold green]✓[/] Filter {type_str}: [cyan]/{pattern}/{cs}[/]"
+            )
 
         # Note: Textual mode rebuilds log in TailApp._handle_command() after this returns
 

--- a/pgtail_py/cli_tail_help.py
+++ b/pgtail_py/cli_tail_help.py
@@ -234,23 +234,23 @@ def show_command_help(
     see_also = help_info.get("see_also", "")
 
     if log_widget is not None:
-        log_widget.write_line(f"[bold cyan]{cmd_lower.upper()}[/bold cyan]")
-        log_widget.write_line(f"  [dim]{short}[/dim]")
-        log_widget.write_line("")
-        log_widget.write_line(f"[bold]Usage:[/bold] [green]{usage}[/green]")
-        log_widget.write_line("")
+        log_widget.write_markup_line(f"[bold cyan]{cmd_lower.upper()}[/bold cyan]")
+        log_widget.write_markup_line(f"  [dim]{short}[/dim]")
+        log_widget.write_markup_line("")
+        log_widget.write_markup_line(f"[bold]Usage:[/bold] [green]{usage}[/green]")
+        log_widget.write_markup_line("")
         if description:
-            log_widget.write_line(f"  {description}")
-            log_widget.write_line("")
+            log_widget.write_markup_line(f"  {description}")
+            log_widget.write_markup_line("")
         if examples:
-            log_widget.write_line("[bold]Examples:[/bold]")
+            log_widget.write_markup_line("[bold]Examples:[/bold]")
             for ex in examples:
-                log_widget.write_line(f"  [yellow]{ex}[/yellow]")
-            log_widget.write_line("")
+                log_widget.write_markup_line(f"  [yellow]{ex}[/yellow]")
+            log_widget.write_markup_line("")
         if aliases:
-            log_widget.write_line(f"[bold]Aliases:[/bold] [dim]{aliases}[/dim]")
+            log_widget.write_markup_line(f"[bold]Aliases:[/bold] [dim]{aliases}[/dim]")
         if see_also:
-            log_widget.write_line(f"[bold]See also:[/bold] [dim]{see_also}[/dim]")
+            log_widget.write_markup_line(f"[bold]See also:[/bold] [dim]{see_also}[/dim]")
 
     return True
 
@@ -290,22 +290,22 @@ def handle_help_command(
             ("Home", "Go to top"),
             ("End", "Go to bottom (resume FOLLOW mode)"),
         ]
-        log_widget.write_line("[bold cyan]Navigation[/bold cyan]")
+        log_widget.write_markup_line("[bold cyan]Navigation[/bold cyan]")
         for key, desc in nav_keys:
-            log_widget.write_line(f"  [green]{key:<12}[/green] [dim]{desc}[/dim]")
+            log_widget.write_markup_line(f"  [green]{key:<12}[/green] [dim]{desc}[/dim]")
 
-        log_widget.write_line("")
+        log_widget.write_markup_line("")
 
         utility_keys = [
             ("Ctrl+L", "Redraw screen"),
             ("F12", "Toggle debug overlay"),
             ("Ctrl+C", "Exit tail mode"),
         ]
-        log_widget.write_line("[bold cyan]Utility Keys[/bold cyan]")
+        log_widget.write_markup_line("[bold cyan]Utility Keys[/bold cyan]")
         for key, desc in utility_keys:
-            log_widget.write_line(f"  [green]{key:<12}[/green] [dim]{desc}[/dim]")
+            log_widget.write_markup_line(f"  [green]{key:<12}[/green] [dim]{desc}[/dim]")
 
-        log_widget.write_line("")
+        log_widget.write_markup_line("")
 
         # Commands section
         commands = [
@@ -328,9 +328,9 @@ def handle_help_command(
             ("export <path>", "Export entries to file"),
             ("stop/exit/q", "Exit tail mode"),
         ]
-        log_widget.write_line("[bold cyan]Commands[/bold cyan]")
+        log_widget.write_markup_line("[bold cyan]Commands[/bold cyan]")
         for cmd, desc in commands:
-            log_widget.write_line(f"  [yellow]{cmd:<12}[/yellow] [dim]{desc}[/dim]")
+            log_widget.write_markup_line(f"  [yellow]{cmd:<12}[/yellow] [dim]{desc}[/dim]")
 
     return True
 
@@ -348,7 +348,7 @@ def handle_help_keys_command(log_widget: TailLog | None = None) -> bool:
 
     if log_widget is not None:
         for category, bindings in KEYBINDINGS.items():
-            log_widget.write_line(f"[bold cyan]{category}[/bold cyan]")
+            log_widget.write_markup_line(f"[bold cyan]{category}[/bold cyan]")
             for key, desc in bindings:
-                log_widget.write_line(f"  [green]{key:<16}[/green] [dim]{desc}[/dim]")
+                log_widget.write_markup_line(f"  [green]{key:<16}[/green] [dim]{desc}[/dim]")
     return True

--- a/pgtail_py/display.py
+++ b/pgtail_py/display.py
@@ -17,6 +17,8 @@ from prompt_toolkit.formatted_text import FormattedText, OneStyleAndTextTuple
 from pgtail_py.highlighters.sql import detect_sql_content, highlight_sql
 
 if TYPE_CHECKING:
+    from rich.text import Text
+
     from pgtail_py.parser import LogEntry
     from pgtail_py.theme import Theme
 
@@ -528,11 +530,11 @@ def format_entry(
     return format_entry_compact(entry, theme, use_semantic_highlighting)
 
 
-def format_entry_as_rich(entry: LogEntry) -> str:
-    """Format entry as Rich Text markup string for Textual widgets.
+def format_entry_as_rich(entry: LogEntry) -> Text:
+    """Format entry as Rich Text for Textual widgets.
 
-    Delegates to tail_rich.format_entry_compact() which returns a Rich
-    console markup string with styled log levels, timestamps, and messages.
+    Delegates to tail_rich.format_entry_compact() which returns Rich Text with
+    styled log levels, timestamps, and messages.
 
     This function provides integration between the display module and the
     Textual-based tail mode, allowing consistent formatting across both
@@ -542,7 +544,7 @@ def format_entry_as_rich(entry: LogEntry) -> str:
         entry: Log entry to format.
 
     Returns:
-        Rich console markup string with styled content.
+        Rich Text with styled content.
     """
     from pgtail_py.tail_rich import format_entry_compact as format_rich
 

--- a/pgtail_py/highlighter.py
+++ b/pgtail_py/highlighter.py
@@ -8,7 +8,7 @@ This module provides:
 - GroupedRegexHighlighter: Base class for regex with named groups
 - KeywordHighlighter: Base class for Aho-Corasick keyword matching
 - HighlighterChain: Compositor that applies multiple highlighters
-- escape_brackets: Utility to escape Rich markup in text
+- Rich Text builders for Textual rendering
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
 import ahocorasick  # type: ignore[import-untyped]
 from prompt_toolkit.formatted_text import FormattedText
+from rich.text import Text
 
 if TYPE_CHECKING:
     from pgtail_py.theme import Theme
@@ -252,7 +253,7 @@ class Highlighter(Protocol):
         """
         ...
 
-    def apply_rich(self, text: str, theme: Theme) -> str:
+    def apply_rich_text(self, text: str, theme: Theme) -> Text:
         """Apply highlighting for Textual/Rich (tail mode).
 
         Args:
@@ -260,32 +261,9 @@ class Highlighter(Protocol):
             theme: Current theme for style lookups.
 
         Returns:
-            Rich markup string with [style]text[/] tags.
+            Rich Text with literal content and style spans.
         """
         ...
-
-
-# =============================================================================
-# Escape Brackets Utility
-# =============================================================================
-
-
-def escape_brackets(text: str) -> str:
-    """Escape brackets that could be interpreted as Rich markup.
-
-    Rich uses [style]...[/] syntax for markup. Any literal brackets
-    in log content (like [bold] or [123]) must be escaped.
-
-    Args:
-        text: Text that may contain brackets.
-
-    Returns:
-        Text with [ escaped as \\[
-    """
-    # Fast path: skip replace if no brackets present
-    if "[" not in text:
-        return text
-    return text.replace("[", "\\[")
 
 
 # =============================================================================
@@ -403,7 +381,7 @@ class RegexHighlighter:
 
         return _build_formatted_text(text, matches, theme)
 
-    def apply_rich(self, text: str, theme: Theme) -> str:
+    def apply_rich_text(self, text: str, theme: Theme) -> Text:
         """Apply highlighting for Rich/Textual.
 
         Args:
@@ -411,16 +389,16 @@ class RegexHighlighter:
             theme: Current theme for style lookups.
 
         Returns:
-            Rich markup string.
+            Rich Text with literal content and style spans.
         """
         if is_color_disabled() or not text:
-            return escape_brackets(text)
+            return Text(text)
 
         matches = self.find_matches(text, theme)
         if not matches:
-            return escape_brackets(text)
+            return Text(text)
 
-        return _build_rich_markup(text, matches, theme)
+        return _build_rich_text(text, matches, theme)
 
 
 # =============================================================================
@@ -530,7 +508,7 @@ class GroupedRegexHighlighter:
 
         return _build_formatted_text(text, matches, theme)
 
-    def apply_rich(self, text: str, theme: Theme) -> str:
+    def apply_rich_text(self, text: str, theme: Theme) -> Text:
         """Apply highlighting for Rich/Textual.
 
         Args:
@@ -538,16 +516,16 @@ class GroupedRegexHighlighter:
             theme: Current theme for style lookups.
 
         Returns:
-            Rich markup string.
+            Rich Text with literal content and style spans.
         """
         if is_color_disabled() or not text:
-            return escape_brackets(text)
+            return Text(text)
 
         matches = self.find_matches(text, theme)
         if not matches:
-            return escape_brackets(text)
+            return Text(text)
 
-        return _build_rich_markup(text, matches, theme)
+        return _build_rich_text(text, matches, theme)
 
 
 # =============================================================================
@@ -672,7 +650,7 @@ class KeywordHighlighter:
 
         return _build_formatted_text(text, matches, theme)
 
-    def apply_rich(self, text: str, theme: Theme) -> str:
+    def apply_rich_text(self, text: str, theme: Theme) -> Text:
         """Apply highlighting for Rich/Textual.
 
         Args:
@@ -680,16 +658,16 @@ class KeywordHighlighter:
             theme: Current theme for style lookups.
 
         Returns:
-            Rich markup string.
+            Rich Text with literal content and style spans.
         """
         if is_color_disabled() or not text:
-            return escape_brackets(text)
+            return Text(text)
 
         matches = self.find_matches(text, theme)
         if not matches:
-            return escape_brackets(text)
+            return Text(text)
 
-        return _build_rich_markup(text, matches, theme)
+        return _build_rich_text(text, matches, theme)
 
 
 # =============================================================================
@@ -823,7 +801,7 @@ class HighlighterChain:
 
         return result
 
-    def apply_rich(self, text: str, theme: Theme) -> str:
+    def apply_rich_text(self, text: str, theme: Theme) -> Text:
         """Apply all highlighters for Rich/Textual.
 
         Args:
@@ -831,10 +809,10 @@ class HighlighterChain:
             theme: Current theme for style lookups.
 
         Returns:
-            Rich markup string.
+            Rich Text with literal content and style spans.
         """
         if is_color_disabled() or not text or not self._highlighters:
-            return escape_brackets(text)
+            return Text(text)
 
         # Apply depth limiting (FR-006, FR-012)
         truncated = False
@@ -847,16 +825,14 @@ class HighlighterChain:
         # Collect all matches from all highlighters
         all_matches = self._collect_matches(process_text, theme)
         if not all_matches:
-            if truncated:
-                return escape_brackets(process_text) + escape_brackets(text[self._max_length :])
-            return escape_brackets(text)
+            return Text(text)
 
         # Apply overlap prevention and build output
-        result = _build_rich_markup_with_tracker(process_text, all_matches, theme)
+        result = _build_rich_text_with_tracker(process_text, all_matches, theme)
 
         # Append truncated portion if needed
         if truncated:
-            result = result + escape_brackets(text[self._max_length :])
+            result.append(text[self._max_length :])
 
         return result
 
@@ -1081,8 +1057,8 @@ def _build_formatted_text(text: str, matches: list[Match], theme: Theme) -> Form
     return FormattedText(result)
 
 
-def _build_rich_markup(text: str, matches: list[Match], theme: Theme) -> str:
-    """Build Rich markup from matches (no overlap prevention).
+def _build_rich_text(text: str, matches: list[Match], theme: Theme) -> Text:
+    """Build Rich Text from matches (no overlap prevention).
 
     Used by individual highlighters that produce non-overlapping matches.
 
@@ -1092,15 +1068,15 @@ def _build_rich_markup(text: str, matches: list[Match], theme: Theme) -> str:
         theme: Current theme.
 
     Returns:
-        Rich markup string.
+        Rich Text with literal content and style spans.
     """
     if not matches:
-        return escape_brackets(text)
+        return Text(text)
 
     # Sort by start position
     sorted_matches = sorted(matches, key=lambda m: m.start)
 
-    result: list[str] = []
+    result = Text()
     pos = 0
 
     for m in sorted_matches:
@@ -1110,21 +1086,21 @@ def _build_rich_markup(text: str, matches: list[Match], theme: Theme) -> str:
 
         # Add unstyled text before this match
         if pos < m.start:
-            result.append(escape_brackets(text[pos : m.start]))
+            result.append(text[pos : m.start])
 
         # Add styled match
         style = _get_rich_style(theme, m.style)
         if style:
-            result.append(f"[{style}]{escape_brackets(text[m.start : m.end])}[/]")
+            result.append(text[m.start : m.end], style=style)
         else:
-            result.append(escape_brackets(text[m.start : m.end]))
+            result.append(text[m.start : m.end])
         pos = m.end
 
     # Add remaining unstyled text
     if pos < len(text):
-        result.append(escape_brackets(text[pos:]))
+        result.append(text[pos:])
 
-    return "".join(result)
+    return result
 
 
 def _build_formatted_text_with_tracker(
@@ -1173,12 +1149,12 @@ def _build_formatted_text_with_tracker(
     return FormattedText(result)
 
 
-def _build_rich_markup_with_tracker(
+def _build_rich_text_with_tracker(
     text: str,
     matches: list[tuple[int, int, str, int]],
     theme: Theme,
-) -> str:
-    """Build Rich markup with OccupancyTracker for overlap prevention.
+) -> Text:
+    """Build Rich Text with OccupancyTracker for overlap prevention.
 
     Args:
         text: Original text.
@@ -1186,10 +1162,10 @@ def _build_rich_markup_with_tracker(
         theme: Current theme.
 
     Returns:
-        Rich markup string.
+        Rich Text with literal content and style spans.
     """
     if not matches:
-        return escape_brackets(text)
+        return Text(text)
 
     # Sort by start position, then by priority (lower priority wins on tie)
     # Use in-place sort for performance
@@ -1202,7 +1178,7 @@ def _build_rich_markup_with_tracker(
     tracker = OccupancyTracker(text_len)
     is_available = tracker.is_available  # Avoid attribute lookup in loop
     mark_occupied = tracker.mark_occupied
-    result: list[str] = []
+    result = Text()
     append = result.append
     pos = 0
 
@@ -1211,19 +1187,19 @@ def _build_rich_markup_with_tracker(
             mark_occupied(start, end)
             # Output unhighlighted text before this match
             if pos < start:
-                append(escape_brackets(text[pos:start]))
+                append(text[pos:start])
             # Output highlighted match
             rich_style = _get_rich_style(theme, style)
             if rich_style:
-                append(f"[{rich_style}]{escape_brackets(text[start:end])}[/]")
+                append(text[start:end], style=rich_style)
             else:
-                append(escape_brackets(text[start:end]))
+                append(text[start:end])
             pos = end
 
     if pos < text_len:
-        append(escape_brackets(text[pos:]))
+        append(text[pos:])
 
-    return "".join(result)
+    return result
 
 
 # =============================================================================

--- a/pgtail_py/highlighters/sql.py
+++ b/pgtail_py/highlighters/sql.py
@@ -10,7 +10,7 @@ Highlighters in this module:
 
 Also provides legacy compatibility exports:
 - SQLTokenType, SQLToken, SQLTokenizer (from sql_tokenizer.py)
-- SQLHighlighter, highlight_sql, highlight_sql_rich (from sql_highlighter.py)
+- SQLHighlighter, highlight_sql, highlight_sql_text (from sql_highlighter.py)
 - SQLDetectionResult, detect_sql_content (from sql_detector.py)
 
 Migrated from sql_tokenizer.py, sql_highlighter.py, and sql_detector.py.
@@ -24,6 +24,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, NamedTuple
 
 from prompt_toolkit.formatted_text import FormattedText
+from rich.text import Text
 
 from pgtail_py.highlighter import KeywordHighlighter, RegexHighlighter
 from pgtail_py.theme import ColorStyle, Theme
@@ -1049,34 +1050,32 @@ def _color_style_to_rich_markup(style: ColorStyle) -> str:
     return " ".join(parts)
 
 
-def highlight_sql_rich(sql: str, theme: Theme | None = None) -> str:
-    """Convert SQL text to Rich console markup string.
+def highlight_sql_text(sql: str, theme: Theme | None = None) -> Text:
+    """Convert SQL text to styled Rich Text.
 
-    Tokenizes SQL and wraps each token in Rich markup tags using
-    colors from the active theme. Brackets in SQL text are escaped
-    to prevent Rich parsing errors.
+    Tokenizes SQL and appends each token as literal text with Rich style
+    spans from the active theme.
 
     Args:
         sql: SQL text to highlight.
         theme: Theme for color lookup. If None, uses global ThemeManager.
 
     Returns:
-        Rich markup string with styled tokens.
-        If NO_COLOR is set, returns SQL with only bracket escaping.
+        Rich Text with styled tokens. If NO_COLOR is set, returns unstyled Text.
 
     Examples:
-        >>> highlight_sql_rich("SELECT id FROM users")
-        "[bold blue]SELECT[/] [cyan]id[/] [bold blue]FROM[/] [cyan]users[/]"
-        >>> highlight_sql_rich("SELECT arr[1]")
-        "[bold blue]SELECT[/] [cyan]arr[/]\\[1]"
+        >>> highlight_sql_text("SELECT id FROM users").plain
+        "SELECT id FROM users"
+        >>> highlight_sql_text("SELECT arr[1]").plain
+        "SELECT arr[1]"
     """
     # Empty SQL returns empty string
     if not sql:
-        return ""
+        return Text()
 
     # Respect NO_COLOR environment variable
     if is_color_disabled():
-        return sql.replace("[", "\\[")
+        return Text(sql)
 
     # Get theme for color lookup
     if theme is None:
@@ -1085,12 +1084,9 @@ def highlight_sql_rich(sql: str, theme: Theme | None = None) -> str:
     # Tokenize SQL
     tokens = SQLTokenizer().tokenize(sql)
 
-    # Build Rich markup string
-    parts: list[str] = []
+    # Build Rich Text
+    text = Text()
     for token in tokens:
-        # Escape brackets in token text to prevent Rich parsing errors
-        escaped_text = token.text.replace("[", "\\[")
-
         # Get theme key for this token type
         theme_key = TOKEN_TYPE_TO_THEME_KEY.get(token.type, "")
 
@@ -1100,13 +1096,13 @@ def highlight_sql_rich(sql: str, theme: Theme | None = None) -> str:
             markup = _color_style_to_rich_markup(style)
 
             if markup:
-                parts.append(f"[{markup}]{escaped_text}[/]")
+                text.append(token.text, style=markup)
             else:
-                parts.append(escaped_text)
+                text.append(token.text)
         else:
-            parts.append(escaped_text)
+            text.append(token.text)
 
-    return "".join(parts)
+    return text
 
 
 class SQLHighlighter:
@@ -1235,7 +1231,7 @@ __all__ = [
     # SQL Highlighter compatibility (from sql_highlighter.py)
     "SQLHighlighter",
     "highlight_sql",
-    "highlight_sql_rich",
+    "highlight_sql_text",
     "TOKEN_TO_STYLE",
     "TOKEN_TYPE_TO_THEME_KEY",
     "_get_theme_manager",  # Internal but used by tests

--- a/pgtail_py/tail_command_handler.py
+++ b/pgtail_py/tail_command_handler.py
@@ -131,7 +131,9 @@ def handle_export_command(
                 append=False,
                 preserve_markup=False,
             )
-        ctx.log_widget.write_markup_line(f"[bold green]✓[/] Exported {count} entries to [cyan]{path}[/]")
+        ctx.log_widget.write_markup_line(
+            f"[bold green]✓[/] Exported {count} entries to [cyan]{path}[/]"
+        )
     except OSError as e:
         ctx.log_widget.write_markup_line(f"[bold red]✗[/] Export failed: {e}")
 

--- a/pgtail_py/tail_command_handler.py
+++ b/pgtail_py/tail_command_handler.py
@@ -59,7 +59,7 @@ def handle_export_command(
     from pgtail_py.export import ExportFormat, export_to_file
 
     if not args:
-        ctx.log_widget.write_line(
+        ctx.log_widget.write_markup_line(
             "[bold red]✗[/] Usage: export <path> [--format text|json|csv] [--highlighted]"
         )
         return
@@ -76,7 +76,7 @@ def handle_export_command(
             try:
                 fmt = ExportFormat.from_string(args[i + 1])
             except ValueError as e:
-                ctx.log_widget.write_line(f"[bold red]✗[/] {e}")
+                ctx.log_widget.write_markup_line(f"[bold red]✗[/] {e}")
                 return
             i += 2
         elif arg == "--highlighted":
@@ -86,11 +86,11 @@ def handle_export_command(
             path_str = arg
             i += 1
         else:
-            ctx.log_widget.write_line(f"[bold red]✗[/] Unknown option: {arg}")
+            ctx.log_widget.write_markup_line(f"[bold red]✗[/] Unknown option: {arg}")
             return
 
     if not path_str:
-        ctx.log_widget.write_line("[bold red]✗[/] No output path specified")
+        ctx.log_widget.write_markup_line("[bold red]✗[/] No output path specified")
         return
 
     # Expand ~ and resolve path
@@ -100,7 +100,7 @@ def handle_export_command(
     filtered_entries = [e for e in ctx.entries if ctx.entry_filter(e)]
 
     if not filtered_entries:
-        ctx.log_widget.write_line(
+        ctx.log_widget.write_markup_line(
             "[yellow]⚠[/] No entries to export (buffer empty or all filtered)"
         )
         return
@@ -120,7 +120,7 @@ def handle_export_command(
                         theme=ctx.state.theme_manager.current_theme,
                         highlighting_config=ctx.state.highlighting_config,
                     )
-                    f.write(formatted + "\n")
+                    f.write(formatted.markup + "\n")
                     count += 1
         else:
             # Standard export (strips markup for clean text/JSON/CSV)
@@ -131,9 +131,9 @@ def handle_export_command(
                 append=False,
                 preserve_markup=False,
             )
-        ctx.log_widget.write_line(f"[bold green]✓[/] Exported {count} entries to [cyan]{path}[/]")
+        ctx.log_widget.write_markup_line(f"[bold green]✓[/] Exported {count} entries to [cyan]{path}[/]")
     except OSError as e:
-        ctx.log_widget.write_line(f"[bold red]✗[/] Export failed: {e}")
+        ctx.log_widget.write_markup_line(f"[bold red]✗[/] Export failed: {e}")
 
 
 def handle_command(command_text: str, ctx: TailCommandContext) -> None:
@@ -203,20 +203,20 @@ def handle_command(command_text: str, ctx: TailCommandContext) -> None:
         if not args:
             current = ctx.state.theme_manager.current_theme
             if current:
-                log_widget.write_line(f"[dim]Current theme:[/] [bold cyan]{current.name}[/]")
+                log_widget.write_markup_line(f"[dim]Current theme:[/] [bold cyan]{current.name}[/]")
             else:
-                log_widget.write_line("[dim]No theme set[/]")
+                log_widget.write_markup_line("[dim]No theme set[/]")
         else:
             theme_name = args[0]
             if ctx.state.theme_manager.switch_theme(theme_name):
                 ctx.rebuild_log(
-                    on_complete=lambda: log_widget.write_line(
+                    on_complete=lambda: log_widget.write_markup_line(
                         f"[bold green]✓[/] Switched to theme [bold cyan]{theme_name}[/]"
                     )
                 )
             else:
                 available = ", ".join(sorted(ctx.state.theme_manager._themes.keys()))
-                log_widget.write_line(
+                log_widget.write_markup_line(
                     f"[bold red]✗[/] Unknown theme [bold yellow]{theme_name}[/]. "
                     f"Available: {available}"
                 )
@@ -315,7 +315,7 @@ def handle_command(command_text: str, ctx: TailCommandContext) -> None:
                 feedback = "[yellow]Highlighting disabled[/yellow]"
             if feedback:
                 msg = feedback  # capture for closure
-                ctx.rebuild_log(on_complete=lambda: log_widget.write_line(msg))
+                ctx.rebuild_log(on_complete=lambda: log_widget.write_markup_line(msg))
             else:
                 ctx.rebuild_log()
 
@@ -334,6 +334,6 @@ def handle_command(command_text: str, ctx: TailCommandContext) -> None:
             key = args[0]
             value = args[1] if len(args) > 1 else ""
             msg = f"[green]Set[/green] [cyan]{key}[/cyan] = [magenta]{value}[/magenta]"
-            ctx.rebuild_log(on_complete=lambda: log_widget.write_line(msg))
+            ctx.rebuild_log(on_complete=lambda: log_widget.write_markup_line(msg))
 
     ctx.update_status()

--- a/pgtail_py/tail_log.py
+++ b/pgtail_py/tail_log.py
@@ -15,14 +15,15 @@ Classes:
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable
 from typing import Any, ClassVar
 
-from rich.errors import MarkupError
+from rich.cells import cell_len
 from rich.style import Style
 from rich.text import Text
 from textual import events
 from textual.binding import Binding, BindingType
-from textual.geometry import Offset
+from textual.geometry import Offset, Size
 from textual.message import Message
 from textual.selection import Selection
 from textual.strip import Strip
@@ -161,6 +162,130 @@ class TailLog(Log):
         self._cursor_col: int = 0
         # Track mouse down position to detect drag vs click
         self._mouse_down_pos: tuple[int, int] | None = None
+        # Rich renderables parallel Textual Log._lines. _lines stores plain text
+        # for sizing, navigation, and copying; _rich_lines stores style spans.
+        self._rich_lines: list[Text] = []
+
+    def write_text_line(
+        self,
+        line: Text,
+        scroll_end: bool | None = None,
+    ) -> TailLog:
+        """Write a styled Rich Text line.
+
+        Args:
+            line: Rich Text to append. Literal content is never parsed as markup.
+            scroll_end: Scroll to the end after writing, or ``None`` to use auto-scroll.
+
+        Returns:
+            This widget.
+        """
+        self.write_text_lines([line], scroll_end)
+        return self
+
+    def write_text_lines(
+        self,
+        lines: Iterable[Text],
+        scroll_end: bool | None = None,
+    ) -> TailLog:
+        """Write styled Rich Text lines.
+
+        This mirrors Textual Log.write_lines(), but stores a parallel rich-text
+        representation so rendering can avoid Rich markup parsing.
+        """
+        is_vertical_scroll_end = self.is_vertical_scroll_end
+        auto_scroll = self.auto_scroll if scroll_end is None else scroll_end
+
+        new_rich_lines: list[Text] = []
+        for line in lines:
+            if not line.plain:
+                continue
+            new_rich_lines.extend(line.split("\n"))
+
+        if not new_rich_lines:
+            return self
+
+        start_line = len(self._lines)
+        new_plain_lines = [line.plain for line in new_rich_lines]
+        self._lines.extend(new_plain_lines)
+        self._rich_lines.extend(new_rich_lines)
+
+        if self.max_lines is not None and len(self._lines) > self.max_lines:
+            self._prune_max_lines()
+
+        self.virtual_size = Size(self._width, len(self._lines))
+        self._update_size(self._updates, new_plain_lines)
+        self.refresh_lines(start_line, len(new_plain_lines))
+        if (
+            auto_scroll
+            and not self.is_vertical_scrollbar_grabbed
+            and is_vertical_scroll_end
+        ):
+            self.scroll_end(animate=False, immediate=True, x_axis=False)
+        else:
+            self.refresh()
+        return self
+
+    def write_line(
+        self,
+        line: str,
+        scroll_end: bool | None = None,
+    ) -> TailLog:
+        """Write a plain text line.
+
+        Markup is intentionally not parsed here. Use ``write_markup_line`` for
+        trusted UI markup or ``write_text_line`` for structured styled output.
+        """
+        self.write_text_line(Text(line), scroll_end)
+        return self
+
+    def write_lines(
+        self,
+        lines: Iterable[str],
+        scroll_end: bool | None = None,
+    ) -> TailLog:
+        """Write plain text lines."""
+        self.write_text_lines((Text(line) for line in lines), scroll_end)
+        return self
+
+    def write_markup_line(
+        self,
+        line: str,
+        scroll_end: bool | None = None,
+    ) -> TailLog:
+        """Write trusted Rich markup as a styled line.
+
+        This is for static application UI strings only. Log content and user
+        patterns should be passed as literal Text through ``write_text_line``.
+        """
+        self.write_text_line(Text.from_markup(line), scroll_end)
+        return self
+
+    def clear(self) -> TailLog:
+        """Clear stored plain and styled lines."""
+        super().clear()
+        self._rich_lines.clear()
+        return self
+
+    def _prune_max_lines(self) -> None:
+        """Prune plain and styled line stores together."""
+        if self.max_lines is None:
+            return
+        remove_lines = len(self._lines) - self.max_lines
+        if remove_lines > 0:
+            del self._rich_lines[:remove_lines]
+        super()._prune_max_lines()
+
+    def _update_size(self, updates: int, lines: list[str]) -> None:
+        """Update width synchronously from plain lines.
+
+        Textual's base implementation runs this in a worker thread. Keeping the
+        width update local avoids touching Rich Text objects across threads.
+        """
+        if lines:
+            _process_line = self._process_line
+            max_length = max(cell_len(_process_line(line)) for line in lines)
+            self._update_maximum_width(updates, max_length)
 
     @property
     def cursor_line(self) -> int:
@@ -283,12 +408,10 @@ class TailLog(Log):
     # Column navigation actions (for character-wise visual mode)
 
     def _get_line_length(self, line_idx: int) -> int:
-        """Get the plain text length of a line (without markup)."""
+        """Get the plain text length of a line."""
         if line_idx < 0 or line_idx >= len(self._lines):
             return 0
-        line = self._lines[line_idx]
-        plain_line = self._strip_markup(line)
-        return len(plain_line)
+        return len(self._lines[line_idx])
 
     def action_cursor_left(self) -> None:
         """Move cursor left one character (h key), wrapping to previous line."""
@@ -580,17 +703,7 @@ class TailLog(Log):
             start_line, end_line = end_line, start_line
             start_col, end_col = end_col, start_col
 
-        # Get plain text lines using Rich's parser for accurate column slicing
-        # (matches how lines are rendered)
-        plain_lines: list[str] = []
-        for i in range(start_line, end_line + 1):
-            try:
-                rich_text = Text.from_markup(self._lines[i])
-                plain_lines.append(rich_text.plain)
-            except MarkupError:
-                # Fall back to stripping markup manually if parsing fails
-                # Uses smart stripping that preserves PIDs like [12345]
-                plain_lines.append(self._strip_markup(self._lines[i]))
+        plain_lines = self._lines[start_line : end_line + 1]
 
         if not plain_lines:
             return ""
@@ -676,19 +789,19 @@ class TailLog(Log):
 
         return success
 
-    # Rendering override for Rich markup support
+    # Rendering override for structured Rich Text support
 
     def _render_line_strip(self, y: int, rich_style: Style) -> Strip:
-        """Render a line with Rich markup support.
+        """Render a line with Rich Text support.
 
-        Overrides parent to parse Rich console markup in log lines,
-        enabling colored output for log levels, timestamps, etc.
+        Overrides parent to render stored Rich Text objects, enabling colored
+        output for log levels, timestamps, etc. without parsing log content as
+        Rich markup.
 
         Uses the inherited ``_render_line_cache`` (LRU, 1024 slots) so
-        that lines which haven't changed are not re-parsed through
-        ``Text.from_markup()`` on every frame.  The cache is bypassed
-        whenever a text selection is active (selection styling varies
-        per-render) and is cleared automatically by the parent on
+        that lines which haven't changed are not re-rendered on every frame.
+        The cache is bypassed whenever a text selection is active (selection
+        styling varies per-render) and is cleared automatically by the parent on
         ``clear()``, ``notify_style_update()``, ``selection_updated()``,
         and ``_prune_max_lines()``.
 
@@ -703,10 +816,11 @@ class TailLog(Log):
         if selection is None and y in self._render_line_cache:
             return self._render_line_cache[y]
 
-        _line = self._process_line(self._lines[y])
-
-        # Parse Rich markup instead of plain text
-        line_text = Text.from_markup(_line)
+        if y < len(self._rich_lines):
+            line_text = self._rich_lines[y].copy()
+        else:
+            line_text = Text(self._lines[y])
+        line_text.expand_tabs()
         line_text.no_wrap = True
 
         # Apply ONLY background from rich_style to entire line for consistent bg

--- a/pgtail_py/tail_log.py
+++ b/pgtail_py/tail_log.py
@@ -216,11 +216,7 @@ class TailLog(Log):
         self.virtual_size = Size(self._width, len(self._lines))
         self._update_size(self._updates, new_plain_lines)
         self.refresh_lines(start_line, len(new_plain_lines))
-        if (
-            auto_scroll
-            and not self.is_vertical_scrollbar_grabbed
-            and is_vertical_scroll_end
-        ):
+        if auto_scroll and not self.is_vertical_scrollbar_grabbed and is_vertical_scroll_end:
             self.scroll_end(animate=False, immediate=True, x_axis=False)
         else:
             self.refresh()

--- a/pgtail_py/tail_rich.py
+++ b/pgtail_py/tail_rich.py
@@ -7,7 +7,7 @@ and secondary field formatting (DETAIL, HINT, CONTEXT, STATEMENT).
 
 Functions:
     format_entry_as_rich: Convert LogEntry to styled Rich Text object.
-    format_entry_compact: Convert LogEntry to plain string for Log widget.
+    format_entry_compact: Convert LogEntry to styled Rich Text for TailLog.
     get_highlighter_chain: Get (or create) the cached HighlighterChain.
     register_all_highlighters: Register all built-in highlighters with registry.
 """
@@ -21,7 +21,7 @@ from rich.text import Text
 from pgtail_py.filter import LogLevel
 from pgtail_py.highlighter import HighlighterChain
 from pgtail_py.highlighter_registry import get_registry
-from pgtail_py.highlighters.sql import detect_sql_content, highlight_sql_rich
+from pgtail_py.highlighters.sql import detect_sql_content, highlight_sql_text
 from pgtail_py.highlighting_config import HighlightingConfig
 
 if TYPE_CHECKING:
@@ -234,11 +234,11 @@ def format_entry_compact(
     theme: Theme | None = None,
     use_semantic_highlighting: bool = True,
     highlighting_config: HighlightingConfig | None = None,
-) -> str:
-    """Convert LogEntry to Rich markup string for Textual Log widget.
+) -> Text:
+    """Convert LogEntry to styled Rich Text for Textual tail mode.
 
-    Formats a log entry as a single-line Rich markup string suitable for
-    the Textual Log widget's write_line() method. Uses a compact
+    Formats a log entry as a single-line Rich Text object suitable for
+    TailLog.write_text_line(). Uses a compact
     format: [source_file] timestamp [pid] LEVEL sql_state: message
 
     When source_file is set (multi-file mode), shows the filename in
@@ -256,24 +256,32 @@ def format_entry_compact(
             If None, uses default config (no custom highlighters).
 
     Returns:
-        Rich markup string representation of the entry.
+        Rich Text representation of the entry.
     """
-    parts: list[str] = []
+    result = Text()
+
+    def append_part(part: str | Text, style: str | None = None) -> None:
+        if result.plain:
+            result.append(" ")
+        if isinstance(part, Text):
+            result.append(part)
+        else:
+            result.append(part, style=style)
 
     # T076: Source file indicator for multi-file mode (before timestamp)
     if entry.source_file:
         # Use magenta for source file to stand out
-        parts.append(f"[magenta]\\[{entry.source_file}][/magenta]")
+        append_part(f"[{entry.source_file}]", style="magenta")
 
     # Timestamp (dim)
     if entry.timestamp:
         ts_str = entry.timestamp.strftime("%H:%M:%S.%f")[:-3]  # HH:MM:SS.mmm
-        parts.append(f"[dim]{ts_str}[/dim]")
+        append_part(ts_str, style="dim")
 
     # PID (dim) - escape brackets, pad to 5 digits for alignment
     if entry.pid:
         pid_str = str(entry.pid).ljust(5)  # Left-pad to 5 digits
-        parts.append(f"[dim]\\[{pid_str}][/dim]")
+        append_part(f"[{pid_str}]", style="dim")
 
     # Level name with color (padded for alignment) + colon
     # Combined into one part so " ".join() doesn't add space between level and colon
@@ -282,40 +290,39 @@ def format_entry_compact(
 
     if entry.sql_state:
         # Level + SQL state + colon
-        if level_style:
-            parts.append(f"[{level_style}]{level_name}[/][cyan]{entry.sql_state}[/]:")
-        else:
-            parts.append(f"{level_name}[cyan]{entry.sql_state}[/]:")
+        level_part = Text()
+        level_part.append(level_name, style=level_style)
+        level_part.append(entry.sql_state, style="cyan")
+        level_part.append(":")
+        append_part(level_part)
     else:
         # Level + colon
-        if level_style:
-            parts.append(f"[{level_style}]{level_name}[/]:")
-        else:
-            parts.append(f"{level_name}:")
+        level_part = Text()
+        level_part.append(level_name, style=level_style)
+        level_part.append(":")
+        append_part(level_part)
 
     # Message - apply highlighting
     if use_semantic_highlighting and theme is not None:
         # Apply semantic highlighting via highlighter chain
         highlighted_message = _highlight_message(entry.message, theme, highlighting_config)
-        parts.append(highlighted_message)
+        append_part(highlighted_message)
     else:
         # Fallback: detect and highlight SQL content only
         detection = detect_sql_content(entry.message)
         if detection:
-            # SQL detected: escape prefix, highlight SQL, escape suffix
-            prefix = detection.prefix.replace("[", "\\[")
-            highlighted_sql = highlight_sql_rich(detection.sql, theme=theme)
-            suffix = detection.suffix.replace("[", "\\[")
-            parts.append(f"{prefix}{highlighted_sql}{suffix}")
+            # SQL detected: append prefix/suffix literally and SQL with spans.
+            message = Text(detection.prefix)
+            message.append(highlight_sql_text(detection.sql, theme=theme))
+            message.append(detection.suffix)
+            append_part(message)
         else:
-            # No SQL: just escape brackets to prevent Rich markup parsing
-            safe_message = entry.message.replace("[", "\\[")
-            parts.append(safe_message)
+            append_part(entry.message)
 
-    return " ".join(parts)
+    return result
 
 
-def _highlight_message(message: str, theme: Theme, config: HighlightingConfig | None = None) -> str:
+def _highlight_message(message: str, theme: Theme, config: HighlightingConfig | None = None) -> Text:
     """Apply semantic highlighting to a log message.
 
     Uses the highlighter chain for pattern-based highlighting. SQL content
@@ -328,10 +335,10 @@ def _highlight_message(message: str, theme: Theme, config: HighlightingConfig | 
         config: Highlighting configuration with custom highlighters.
 
     Returns:
-        Rich markup string with highlighting.
+        Rich Text with highlighting.
     """
     # Get highlighter chain (with custom highlighters from config)
     chain = get_highlighter_chain(config)
 
     # Apply semantic highlighting
-    return chain.apply_rich(message, theme)
+    return chain.apply_rich_text(message, theme)

--- a/pgtail_py/tail_rich.py
+++ b/pgtail_py/tail_rich.py
@@ -322,7 +322,9 @@ def format_entry_compact(
     return result
 
 
-def _highlight_message(message: str, theme: Theme, config: HighlightingConfig | None = None) -> Text:
+def _highlight_message(
+    message: str, theme: Theme, config: HighlightingConfig | None = None
+) -> Text:
     """Apply semantic highlighting to a log message.
 
     Uses the highlighter chain for pattern-based highlighting. SQL content

--- a/pgtail_py/tail_textual.py
+++ b/pgtail_py/tail_textual.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, ClassVar
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
+from textual.css.query import NoMatches
 from textual.widgets import Input, Rule, Static
 
 from pgtail_py.cli_tail_help import COMMAND_HELP
@@ -470,15 +471,15 @@ class TailApp(App[None]):
         except PermissionError:
             # File exists but we can't read it - show helpful message
             log_widget = self.query_one("#log", TailLog)
-            log_widget.write_line(
+            log_widget.write_markup_line(
                 "[bold yellow]Warning:[/] Cannot read log file due to permissions"
             )
-            log_widget.write_line(f"[dim]File:[/] {self._log_path}")
-            log_widget.write_line("")
+            log_widget.write_markup_line(f"[dim]File:[/] {self._log_path}")
+            log_widget.write_markup_line("")
 
             # Platform-specific fix suggestions
             for line in get_log_permission_advice(rich_markup=True):
-                log_widget.write_line(line)
+                log_widget.write_markup_line(line)
 
             # Mark file as permission denied and unavailable in status
             self._status.set_file_permission_denied(True)
@@ -584,7 +585,7 @@ class TailApp(App[None]):
         # Show completion message in log
         log_widget = self.query_one("#log", TailLog)
         lines_read = self._stdin_reader.lines_read if self._stdin_reader else 0
-        log_widget.write_line(
+        log_widget.write_markup_line(
             f"[dim]--- stdin complete ({lines_read} lines loaded) - press 'q' to quit ---[/]"
         )
 
@@ -804,7 +805,7 @@ class TailApp(App[None]):
         was_at_end = log_widget.is_vertical_scroll_end
 
         # Add to log
-        log_widget.write_line(formatted)
+        log_widget.write_text_line(formatted)
 
         # Update status counts (only for displayed entries)
         if self._status:
@@ -909,7 +910,7 @@ class TailApp(App[None]):
                         theme=self._state.theme_manager.current_theme,
                         highlighting_config=self._state.highlighting_config,
                     )
-                    log_widget.write_line(formatted)
+                    log_widget.write_text_line(formatted)
                     if self._status:
                         self._status.update_from_entry(entry)
 
@@ -933,7 +934,7 @@ class TailApp(App[None]):
                             theme=self._state.theme_manager.current_theme,
                             highlighting_config=self._state.highlighting_config,
                         )
-                        log_widget.write_line(formatted)
+                        log_widget.write_text_line(formatted)
                         if self._status:
                             self._status.update_from_entry(entry)
 
@@ -993,14 +994,23 @@ class TailApp(App[None]):
 
     def _update_status(self) -> None:
         """Update the header and status bar displays with styled Rich text."""
-        if self._status:
-            # Update header with keybinding hints
-            header_widget = self.query_one("#header", Static)
-            header_widget.update(self._status.format_header())
+        if not self._status:
+            return
 
-            # Update status bar with mode, counts, filters
+        try:
+            header_widget = self.query_one("#header", Static)
             status_widget = self.query_one("#status", Static)
-            status_widget.update(self._status.format_rich())
+        except NoMatches:
+            # Background workers and timers (the consumer loop, rebuilds) can
+            # reach here while the widgets aren't in the DOM -- before compose
+            # finishes on startup, or after they're torn down on shutdown.
+            # There is nothing to update in that window.
+            return
+
+        # Update header with keybinding hints
+        header_widget.update(self._status.format_header())
+        # Update status bar with mode, counts, filters
+        status_widget.update(self._status.format_rich())
 
     def _handle_command(self, command_text: str) -> None:
         """Handle a command entered in the input line.

--- a/tests/test_cli_highlight.py
+++ b/tests/test_cli_highlight.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from prompt_toolkit.formatted_text import FormattedText
+from rich.text import Text
 
 from pgtail_py.cli_highlight import (
     format_highlight_list,
@@ -162,13 +163,13 @@ class TestHighlightList:
     def test_format_list_rich_output(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
     ) -> None:
-        """Rich format produces valid markup."""
+        """Rich format produces Text output."""
         result = format_highlight_list_rich(highlighting_config)
 
-        assert isinstance(result, str)
+        assert isinstance(result, Text)
         assert "Semantic Highlighting:" in result
         assert "timestamp" in result
-        assert "[green]" in result or "[red]" in result  # Status colors
+        assert result.spans
 
     def test_format_list_with_global_disabled(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
@@ -1475,16 +1476,16 @@ class TestHighlightPreviewCommand:
         assert success is True
         assert isinstance(output, FormattedText)
 
-    def test_preview_returns_rich_string(
+    def test_preview_returns_rich_text(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
     ) -> None:
-        """Preview returns Rich markup string for Textual mode."""
+        """Preview returns Rich Text for Textual mode."""
         from pgtail_py.cli_highlight import handle_highlight_preview
 
         success, output = handle_highlight_preview(highlighting_config, use_rich=True)
 
         assert success is True
-        assert isinstance(output, str)
+        assert isinstance(output, Text)
 
     def test_preview_shows_enabled_status(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
@@ -1638,21 +1639,42 @@ class TestHighlightPreviewCommand:
 
 
 class TestPreviewRichFormatting:
-    """Tests for Rich markup formatting in preview."""
+    """Tests for Rich Text formatting in preview."""
 
     def test_format_preview_rich_escapes_brackets(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
     ) -> None:
-        """Rich preview escapes brackets in sample content."""
+        """Rich preview preserves bracketed sample content literally."""
         from pgtail_py.cli_highlight import format_preview_rich
 
         highlighting_config.enabled = False  # Disable to get raw content
         output = format_preview_rich(highlighting_config)
 
-        # Brackets in log content should be escaped
-        # The output should be valid Rich markup
         assert output is not None
-        # Should not crash when parsed
+
+    def test_custom_pattern_ending_in_backslash_renders_intact(
+        self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
+    ) -> None:
+        """A custom regex ending in a backslash must remain literal.
+
+        Regex patterns are full of backslashes. They should be displayed as
+        literal Text, never parsed as markup.
+        """
+        from pgtail_py.cli_highlight import format_highlight_list_rich, format_preview_rich
+        from pgtail_py.highlighting_config import CustomHighlighter
+
+        highlighting_config.add_custom(
+            CustomHighlighter(name="winpath", pattern="c:\\users\\", style="cyan")
+        )
+
+        for output in (
+            format_highlight_list_rich(highlighting_config),
+            format_preview_rich(highlighting_config),
+        ):
+            plain = output.plain
+            # The pattern survives verbatim and no closing tag leaks into the text.
+            assert "c:\\users\\" in plain
+            assert "[/]" not in plain
 
     def test_format_preview_rich_shows_category_bold(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
@@ -1662,9 +1684,9 @@ class TestPreviewRichFormatting:
 
         output = format_preview_rich(highlighting_config)
 
-        # Categories should be bold
-        assert "[bold]Structural[/]" in output
-        assert "[bold]Performance[/]" in output
+        assert "Structural" in output
+        assert "Performance" in output
+        assert any(str(span.style) == "bold" for span in output.spans)
 
     def test_format_preview_rich_uses_dim_for_descriptions(
         self, mock_registry: MagicMock, highlighting_config: HighlightingConfig
@@ -1675,7 +1697,7 @@ class TestPreviewRichFormatting:
         output = format_preview_rich(highlighting_config)
 
         # Descriptions should be dim
-        assert "[dim]" in output
+        assert any(str(span.style) == "dim" for span in output.spans)
 
 
 class TestPreviewFormattedTextFormatting:

--- a/tests/test_cli_tail_filters.py
+++ b/tests/test_cli_tail_filters.py
@@ -186,7 +186,7 @@ class TestHandleFilterCommand:
         )
         assert result is True
         # Should have written warning
-        mock_log_widget.write_line.assert_any_call(
+        mock_log_widget.write_markup_line.assert_any_call(
             "[yellow]Warning:[/] Field filtering only works for CSV/JSON logs"
         )
 
@@ -236,7 +236,7 @@ class TestHandleFilterCommand:
             log_widget=mock_log_widget,
         )
         assert result is True
-        mock_log_widget.write_line.assert_called()
+        mock_log_widget.write_markup_line.assert_called()
 
 
 class TestHandleClearCommand:

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -4,7 +4,7 @@ Tests cover:
 - Match dataclass validation (T028)
 - OccupancyTracker functionality (T029)
 - HighlighterChain overlap prevention (T030)
-- escape_brackets utility (T031)
+- Rich Text rendering round-trip behavior
 - RegexHighlighter base class
 - GroupedRegexHighlighter base class
 - KeywordHighlighter base class
@@ -23,7 +23,6 @@ from pgtail_py.highlighter import (
     Match,
     OccupancyTracker,
     RegexHighlighter,
-    escape_brackets,
     is_color_disabled,
 )
 from pgtail_py.theme import ColorStyle, Theme
@@ -179,8 +178,8 @@ class TestHighlighterChain:
     def test_empty_chain(self, mock_theme: Theme) -> None:
         """Empty chain should return original text."""
         chain = HighlighterChain()
-        result = chain.apply_rich("hello world", mock_theme)
-        assert result == "hello world"
+        result = chain.apply_rich_text("hello world", mock_theme)
+        assert result.plain == "hello world"
 
     def test_single_highlighter(self, mock_theme: Theme) -> None:
         """Single highlighter should apply correctly."""
@@ -194,8 +193,9 @@ class TestHighlighterChain:
             )
         )
 
-        result = chain.apply_rich("value: 123", mock_theme)
-        assert "[blue bold]123[/]" in result
+        result = chain.apply_rich_text("value: 123", mock_theme)
+        assert result.plain == "value: 123"
+        assert "[blue bold]123" in result.markup
 
     def test_overlap_prevention_priority(self, mock_theme: Theme) -> None:
         """Higher priority (lower number) should win on overlap."""
@@ -221,10 +221,11 @@ class TestHighlighterChain:
             )
         )
 
-        result = chain.apply_rich("hello world today", mock_theme)
+        result = chain.apply_rich_text("hello world today", mock_theme)
         # "hello world" should be blue bold (hl_test), not green (hl_test2)
-        assert "[blue bold]hello world[/]" in result
-        assert "green" not in result or "world" not in result.split("green")[0]
+        assert result.plain == "hello world today"
+        assert "[blue bold]hello world" in result.markup
+        assert "[green]world" not in result.markup
 
     def test_non_overlapping_matches(self, mock_theme: Theme) -> None:
         """Non-overlapping matches should both apply."""
@@ -248,9 +249,10 @@ class TestHighlighterChain:
             )
         )
 
-        result = chain.apply_rich("abc 123", mock_theme)
-        assert "[green]abc[/]" in result
-        assert "[blue bold]123[/]" in result
+        result = chain.apply_rich_text("abc 123", mock_theme)
+        assert result.plain == "abc 123"
+        assert "[green]abc" in result.markup
+        assert "[blue bold]123" in result.markup
 
     def test_depth_limiting(self, mock_theme: Theme) -> None:
         """Max length should truncate highlighting."""
@@ -267,12 +269,12 @@ class TestHighlighterChain:
 
         # 15 chars, but only first 10 should be highlighted
         text = "abc 123 xyz 456"
-        result = chain.apply_rich(text, mock_theme)
+        result = chain.apply_rich_text(text, mock_theme)
 
         # "123" is within first 10 chars, "456" is beyond
-        assert "[blue bold]123[/]" in result
+        assert "[blue bold]123" in result.markup
         # The "456" should appear but not be highlighted
-        assert "456" in result
+        assert "456" in result.plain
 
     def test_register_duplicate_name(self) -> None:
         """Registering duplicate name should raise."""
@@ -293,34 +295,31 @@ class TestHighlighterChain:
 
 
 # =============================================================================
-# Test escape_brackets (T031)
+# Test Rich Text round-trips
 # =============================================================================
 
 
-class TestEscapeBrackets:
-    """Tests for escape_brackets utility."""
+class TestRichTextRoundTrip:
+    """Tests for literal content in Rich Text output."""
 
-    def test_no_brackets(self) -> None:
-        """Text without brackets should be unchanged."""
-        assert escape_brackets("hello world") == "hello world"
-
-    def test_single_bracket(self) -> None:
-        """Single bracket should be escaped."""
-        assert escape_brackets("[bold]") == "\\[bold]"
-
-    def test_multiple_brackets(self) -> None:
-        """Multiple brackets should all be escaped."""
-        assert escape_brackets("[a][b][c]") == "\\[a]\\[b]\\[c]"
-
-    def test_nested_brackets(self) -> None:
-        """Nested brackets in log output."""
-        text = "[12345] ERROR: connection [local]"
-        expected = "\\[12345] ERROR: connection \\[local]"
-        assert escape_brackets(text) == expected
-
-    def test_empty_string(self) -> None:
-        """Empty string should return empty string."""
-        assert escape_brackets("") == ""
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "hello world",
+            "[bold]",
+            "[a][b][c]",
+            "[12345] ERROR: connection [local]",
+            r"c:\tmp\\",
+            r"\[123]",
+            r"\[abc]",
+            "",
+        ],
+    )
+    def test_literal_text_is_preserved(self, text: str, mock_theme: Theme) -> None:
+        """Rich Text output preserves arbitrary log text literally."""
+        chain = HighlighterChain()
+        result = chain.apply_rich_text(text, mock_theme)
+        assert result.plain == text
 
 
 # =============================================================================
@@ -594,10 +593,9 @@ class TestZeroAllocationEarlyReturn:
 
         # Text with no matching patterns
         text = "plain text with no special patterns"
-        result = chain.apply_rich(text, mock_theme)
+        result = chain.apply_rich_text(text, mock_theme)
 
-        # Should be escaped text (brackets escaped)
-        assert result == text.replace("[", "\\[")
+        assert result.plain == text
 
     def test_chain_empty_text_returns_immediately(self, mock_theme: Theme) -> None:
         """HighlighterChain should return empty string immediately for empty input."""
@@ -610,18 +608,17 @@ class TestZeroAllocationEarlyReturn:
 
         chain = HighlighterChain([highlighter])
 
-        result = chain.apply_rich("", mock_theme)
-        assert result == ""
+        result = chain.apply_rich_text("", mock_theme)
+        assert result.plain == ""
 
     def test_chain_no_highlighters_returns_escaped(self, mock_theme: Theme) -> None:
         """HighlighterChain with no highlighters should return escaped text."""
         chain = HighlighterChain([])
 
         text = "some [text] with brackets"
-        result = chain.apply_rich(text, mock_theme)
+        result = chain.apply_rich_text(text, mock_theme)
 
-        # Should escape brackets
-        assert result == "some \\[text] with brackets"
+        assert result.plain == text
 
     def test_chain_color_disabled_returns_escaped(self, mock_theme: Theme) -> None:
         """HighlighterChain should return escaped text when color is disabled."""
@@ -645,10 +642,9 @@ class TestZeroAllocationEarlyReturn:
 
             utils._color_disabled = None
 
-            result = chain.apply_rich(text, mock_theme)
+            result = chain.apply_rich_text(text, mock_theme)
 
-            # Should be escaped, no highlighting
-            assert result == "test 123 \\[456]"
+            assert result.plain == text
         finally:
             os.environ.pop("NO_COLOR", None)
             from pgtail_py import utils

--- a/tests/test_highlighting_integration.py
+++ b/tests/test_highlighting_integration.py
@@ -19,7 +19,6 @@ from pgtail_py.filter import LogLevel
 from pgtail_py.highlighter import (
     HighlighterChain,
     OccupancyTracker,
-    escape_brackets,
     is_color_disabled,
 )
 from pgtail_py.highlighter_registry import get_registry, reset_registry
@@ -32,6 +31,17 @@ from pgtail_py.tail_rich import (
     reset_highlighter_chain,
 )
 from pgtail_py.theme import ColorStyle, Theme
+
+
+def _has_style(text: object, style: str) -> bool:
+    """Return True if a Rich Text object has a span with this style."""
+    return any(str(span.style) == style for span in getattr(text, "spans", []))
+
+
+def _spans_do_not_overlap(text: object) -> bool:
+    """Return True if Rich Text spans do not overlap."""
+    spans = sorted(getattr(text, "spans", []), key=lambda span: (span.start, span.end))
+    return all(left.end <= right.start for left, right in zip(spans, spans[1:], strict=False))
 
 # =============================================================================
 # Fixtures
@@ -169,7 +179,7 @@ class TestTailModeIntegration:
         )
 
         # Should contain Rich markup (style tags)
-        assert "[" in result
+        assert result.spans
         # Should contain the message content
         assert "duration" in result
         assert "SELECT" in result
@@ -182,10 +192,9 @@ class TestTailModeIntegration:
             sample_log_entry, theme=test_theme, use_semantic_highlighting=False
         )
 
-        # Should still escape brackets but not apply semantic styles
+        # Should preserve literal content without semantic chain styling.
         assert "duration" in result
-        # Brackets should be escaped
-        assert "\\[12345]" in result
+        assert "[12345]" in result.plain
 
     def test_format_entry_without_theme(self, sample_log_entry: LogEntry) -> None:
         """format_entry_compact without theme should use SQL-only highlighting."""
@@ -252,10 +261,10 @@ class TestThemeSwitching:
         chain = get_highlighter_chain()
         text = "duration: 150 ms"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Should have styling from theme
-        assert "[" in result
+        assert result.spans
         assert "150 ms" in result
 
     def test_theme_switch_changes_colors(self) -> None:
@@ -279,16 +288,16 @@ class TestThemeSwitching:
             ui={"hl_duration_slow": ColorStyle(fg="red")},
         )
 
-        result1 = chain.apply_rich(text, theme1)
-        result2 = chain.apply_rich(text, theme2)
+        result1 = chain.apply_rich_text(text, theme1)
+        result2 = chain.apply_rich_text(text, theme2)
 
         # Results should be different (different colors)
         # Both should contain the text but with different styles
         assert "150 ms" in result1
         assert "150 ms" in result2
         # Check style differences
-        if "green" in result1:
-            assert "red" in result2
+        assert _has_style(result1, "green")
+        assert _has_style(result2, "red")
 
     def test_theme_get_style_fallback(self, minimal_theme: Theme) -> None:
         """Theme should return None for missing hl_* keys."""
@@ -307,13 +316,13 @@ class TestThemeSwitching:
         text = "2024-01-15 14:30:45 duration: 50 ms"
 
         # Should not raise even with missing keys
-        result = chain.apply_rich(text, minimal_theme)
+        result = chain.apply_rich_text(text, minimal_theme)
 
         # Should still contain the text
         assert "2024-01-15" in result
         assert "50 ms" in result
         # Duration styling should be present (key exists)
-        assert "[green]" in result or "green" in result
+        assert _has_style(result, "green")
 
 
 # =============================================================================
@@ -361,10 +370,11 @@ class TestNoColor:
         try:
             os.environ["NO_COLOR"] = "1"
 
-            result = chain.apply_rich(text, test_theme)
+            result = chain.apply_rich_text(text, test_theme)
 
-            # Should be escaped but no color tags
-            assert "[" not in result or result.startswith("\\[")
+            # Should be plain text with no style spans.
+            assert result.plain == text
+            assert not result.spans
             assert "duration" in result
         finally:
             if old_value is None:
@@ -426,14 +436,10 @@ class TestNonOverlapping:
         # "123.456" could match duration and number patterns
         text = "duration: 123.456 ms table users"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
-        # Should contain only one style per character (no nesting)
-        # Count open/close brackets should be balanced
-        open_count = result.count("[") - result.count("\\[")
-        close_count = result.count("[/]")
-        # Each styled region has one open and one close
-        assert open_count >= close_count
+        # Should contain only one style per character.
+        assert _spans_do_not_overlap(result)
 
     def test_priority_based_conflict_resolution(self, test_theme: Theme) -> None:
         """Lower priority highlighters should win on conflict."""
@@ -459,10 +465,10 @@ class TestNonOverlapping:
         chain = HighlighterChain([h1, h2])
         text = "test"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Should have style from h1 (lower priority number)
-        assert "gray" in result  # hl_timestamp_date is gray in test_theme
+        assert _has_style(result, "gray")  # hl_timestamp_date is gray in test_theme
 
     def test_nested_pattern_handling(self, test_theme: Theme) -> None:
         """Should handle nested patterns (schema.table within relation)."""
@@ -471,7 +477,7 @@ class TestNonOverlapping:
         # Schema-qualified name
         text = "relation public.users"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Should highlight without errors
         assert "public.users" in result or "public" in result
@@ -483,7 +489,7 @@ class TestNonOverlapping:
         # Line with multiple pattern types
         text = "2024-01-15 [12345] duration: 150 ms relation users"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # All parts should be in result (checking for text content, may include markup)
         assert "2024" in result and "01" in result and "15" in result
@@ -506,7 +512,7 @@ class TestMissingThemeKeys:
         # Timestamp - key doesn't exist in minimal theme
         text = "2024-01-15 14:30:45"
 
-        result = chain.apply_rich(text, minimal_theme)
+        result = chain.apply_rich_text(text, minimal_theme)
 
         # Should still contain the text
         assert "2024-01-15" in result
@@ -520,16 +526,16 @@ class TestMissingThemeKeys:
         # Duration (key exists) and timestamp (key missing)
         text = "2024-01-15 duration: 50 ms"
 
-        result = chain.apply_rich(text, minimal_theme)
+        result = chain.apply_rich_text(text, minimal_theme)
 
         # Duration should be styled (green)
-        assert "green" in result
+        assert _has_style(result, "green")
         # Both parts should be present
         assert "2024-01-15" in result
         assert "50 ms" in result
 
-    def test_all_keys_missing_returns_escaped_text(self) -> None:
-        """Theme with no hl_* keys should return escaped text."""
+    def test_all_keys_missing_preserves_text(self) -> None:
+        """Theme with no hl_* keys should preserve literal text."""
         empty_theme = Theme(
             name="empty",
             description="Empty theme",
@@ -540,12 +546,9 @@ class TestMissingThemeKeys:
         chain = get_highlighter_chain()
         text = "2024-01-15 [12345] LOG: test"
 
-        result = chain.apply_rich(text, empty_theme)
+        result = chain.apply_rich_text(text, empty_theme)
 
-        # Should have escaped brackets
-        assert "\\[12345]" in result
-        # Content should be present
-        assert "test" in result
+        assert result.plain == text
 
 
 # =============================================================================
@@ -559,14 +562,14 @@ class TestEdgeCases:
     def test_empty_text(self, test_theme: Theme) -> None:
         """Empty text should return empty string."""
         chain = get_highlighter_chain()
-        result = chain.apply_rich("", test_theme)
-        assert result == ""
+        result = chain.apply_rich_text("", test_theme)
+        assert result.plain == ""
 
     def test_no_matches(self, test_theme: Theme) -> None:
         """Text with no matches should return escaped text."""
         chain = get_highlighter_chain()
         text = "plain text without patterns"
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
         # Should be escaped (in case there are brackets)
         assert "plain text" in result
 
@@ -582,7 +585,7 @@ class TestEdgeCases:
         # Create text longer than max_length
         text = "duration: 150 ms " * 100  # Much longer than 100 chars
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Should still work without error
         assert "duration" in result
@@ -590,21 +593,44 @@ class TestEdgeCases:
         assert len(result) > 0
 
     def test_rich_markup_like_content(self, test_theme: Theme) -> None:
-        """Content that looks like Rich markup should be escaped."""
+        """Content that looks like Rich markup should remain literal."""
         chain = get_highlighter_chain()
         text = "[bold]not markup[/bold] just text"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
-        # The literal [bold] should be escaped
-        assert "\\[bold]" in result
+        assert result.plain == text
 
-    def test_escape_brackets_utility(self) -> None:
-        """escape_brackets should escape all open brackets."""
-        assert escape_brackets("[test]") == "\\[test]"
-        assert escape_brackets("[[nested]]") == "\\[\\[nested]]"
-        assert escape_brackets("no brackets") == "no brackets"
-        assert escape_brackets("") == ""
+    @pytest.mark.parametrize(
+        "text",
+        [
+            r"c:\users\alexj\\",
+            "x" + "\\" * 2,
+            "x" + "\\" * 3,
+            r"\[",
+            r"\[123]",
+            r"\[abc]",
+            r"[bold]not markup[/bold]",
+        ],
+    )
+    def test_rich_text_preserves_backslash_bracket_cases(
+        self, text: str, test_theme: Theme
+    ) -> None:
+        """Literal log text is preserved without markup escaping."""
+        chain = get_highlighter_chain()
+        assert chain.apply_rich_text(text, test_theme).plain == text
+
+    def test_windows_path_before_styled_token_renders(self) -> None:
+        """A Windows path ending in a backslash is literal before styled text."""
+
+        from pgtail_py.theme import ThemeManager
+
+        theme = ThemeManager().current_theme
+        chain = get_highlighter_chain()
+        text = "to 'c:\\users\\alexj\\sequence_output.txt';"
+
+        rendered = chain.apply_rich_text(text, theme)
+        assert rendered.plain == text
 
     def test_extremely_long_lines_over_10kb(self, test_theme: Theme) -> None:
         """Extremely long lines (>10KB) should be handled with depth limiting (T163).
@@ -624,7 +650,7 @@ class TestEdgeCases:
 
         assert len(text) > 10240  # Verify > 10KB
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Result should contain all the text (escaped)
         assert len(result) >= len(text) - 100  # Allow for markup overhead
@@ -647,7 +673,7 @@ class TestEdgeCases:
         huge_line = "duration: 150 ms " * 6000
 
         start = time.perf_counter()
-        result = chain.apply_rich(huge_line, test_theme)
+        result = chain.apply_rich_text(huge_line, test_theme)
         elapsed = time.perf_counter() - start
 
         # Should complete quickly (< 100ms) due to depth limiting
@@ -677,7 +703,7 @@ class TestSQLContextAwareness:
         # Regular log message with words that are also SQL keywords
         text = "background worker exited with exit code 0"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # "with" should NOT be styled as SQL keyword (no blue)
         # The word should appear but without sql_keyword styling
@@ -698,7 +724,7 @@ class TestSQLContextAwareness:
         ]
 
         for text in messages:
-            result = chain.apply_rich(text, test_theme)
+            result = chain.apply_rich_text(text, test_theme)
             # These common English words should not have SQL keyword styling
             # sql_keyword uses "bold blue" in test_theme
             # The words should be present but not SQL-styled
@@ -711,7 +737,7 @@ class TestSQLContextAwareness:
         # Log message with actual SQL
         text = "statement: SELECT id, name FROM users WHERE id = 1"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # SQL keywords should be styled
         # SELECT, FROM, WHERE should have SQL styling
@@ -725,7 +751,7 @@ class TestSQLContextAwareness:
 
         text = "duration: 5.123 ms statement: SELECT * FROM users"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # SQL keywords should be present (styling may vary by theme)
         assert "SELECT" in result
@@ -737,7 +763,7 @@ class TestSQLContextAwareness:
 
         text = "execute stmt_1: SELECT id FROM accounts WHERE active = true"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # SQL keywords should be present
         assert "SELECT" in result
@@ -751,7 +777,7 @@ class TestSQLContextAwareness:
         # Log message with checkpoint keywords (not SQL)
         text = "checkpoint starting: time"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Checkpoint keywords should still be highlighted
         # They're not SQL highlighters, so they apply everywhere
@@ -765,7 +791,7 @@ class TestSQLContextAwareness:
         # Duration highlighting (non-SQL) + SQL statement
         text = "duration: 150 ms statement: SELECT * FROM users"
 
-        result = chain.apply_rich(text, test_theme)
+        result = chain.apply_rich_text(text, test_theme)
 
         # Duration should be highlighted (performance highlighter)
         assert "150 ms" in result or "150" in result
@@ -818,7 +844,7 @@ class TestPerformanceThroughput:
         start_time = time.perf_counter()
 
         for line in lines_to_process:
-            chain.apply_rich(line, test_theme)
+            chain.apply_rich_text(line, test_theme)
 
         elapsed_time = time.perf_counter() - start_time
 
@@ -849,7 +875,7 @@ class TestPerformanceThroughput:
         start_time = time.perf_counter()
 
         for _ in range(num_iterations):
-            chain.apply_rich(long_line, test_theme)
+            chain.apply_rich_text(long_line, test_theme)
 
         elapsed_time = time.perf_counter() - start_time
 
@@ -906,10 +932,10 @@ class TestCSVJSONLogFormatHighlighting:
         # Message field from a parsed CSV/JSON log entry
         message = "duration: 150.234 ms  statement: SELECT * FROM users"
 
-        result = chain.apply_rich(message, test_theme)
+        result = chain.apply_rich_text(message, test_theme)
 
-        # Should have Rich markup for duration
-        assert "[" in result  # Has markup tags
+        # Should have Rich spans for duration / SQL content.
+        assert result.spans
         assert "150" in result  # Has the duration value
         assert "SELECT" in result  # SQL content preserved
 
@@ -920,7 +946,7 @@ class TestCSVJSONLogFormatHighlighting:
         # Detail field often contains SQL-related info
         detail = "Key (id)=(42) already exists."
 
-        result = chain.apply_rich(detail, test_theme)
+        result = chain.apply_rich_text(detail, test_theme)
 
         # Content should be preserved
         assert "id" in result
@@ -933,7 +959,7 @@ class TestCSVJSONLogFormatHighlighting:
         # Hint field may contain SQL keywords
         hint = "Use UPSERT or ON CONFLICT to handle duplicates."
 
-        result = chain.apply_rich(hint, test_theme)
+        result = chain.apply_rich_text(hint, test_theme)
 
         # Content should be preserved
         assert "UPSERT" in result
@@ -955,7 +981,7 @@ class TestCSVJSONLogFormatHighlighting:
         result = format_entry_compact(entry, theme=test_theme, use_semantic_highlighting=True)
 
         # Should contain styled output
-        assert "[" in result  # Rich markup present
+        assert result.spans  # Rich spans present
         assert "250" in result  # Duration value
         assert "SELECT" in result  # SQL content
 
@@ -1024,7 +1050,7 @@ class TestCSVJSONLogFormatHighlighting:
             "WHERE u.status = 'active' AND u.created_at > $1"
         )
 
-        result = chain.apply_rich(message, test_theme)
+        result = chain.apply_rich_text(message, test_theme)
 
         # All content should be present
         assert "1234.567 ms" in result or ("1234" in result and "567" in result and "ms" in result)

--- a/tests/test_sql_highlighter.py
+++ b/tests/test_sql_highlighter.py
@@ -12,7 +12,7 @@ from pgtail_py.highlighters.sql import (
     SQLToken,
     SQLTokenType,
     _color_style_to_rich_markup,
-    highlight_sql_rich,
+    highlight_sql_text,
 )
 from pgtail_py.theme import ColorStyle, Theme
 
@@ -445,91 +445,80 @@ class TestColorStyleToRichMarkup:
 
 
 class TestHighlightSqlRich:
-    """Tests for highlight_sql_rich() - T010."""
+    """Tests for highlight_sql_text() - T010."""
 
     def test_keywords_highlighted(self) -> None:
-        """SQL keywords should have markup tags."""
-        result = highlight_sql_rich("SELECT id FROM users")
-        # Should have Rich markup tags
-        assert "[" in result
+        """SQL keywords should have Rich Text spans."""
+        result = highlight_sql_text("SELECT id FROM users")
+        assert result.spans
         assert "SELECT" in result
         assert "FROM" in result
 
     def test_brackets_escaped(self) -> None:
-        """Brackets in SQL should be escaped to prevent Rich parsing errors."""
-        result = highlight_sql_rich("SELECT arr[1] FROM table")
-        # Opening bracket should be escaped (the tokenizer treats [1] as separate tokens)
-        assert "\\[" in result
+        """Array subscripts must survive highlighting unchanged."""
+        sql = "SELECT arr[1] FROM table"
+        assert highlight_sql_text(sql).plain == sql
 
     def test_nested_brackets_escaped(self) -> None:
-        """Nested brackets in SQL should all be escaped."""
-        result = highlight_sql_rich("SELECT arr[1][2] FROM table")
-        # Should have escaped brackets
-        assert result.count("\\[") >= 2
+        """Nested subscripts must survive highlighting unchanged."""
+        sql = "SELECT arr[1][2] FROM table"
+        assert highlight_sql_text(sql).plain == sql
 
     def test_empty_sql_returns_empty(self) -> None:
         """Empty SQL should return empty string."""
-        result = highlight_sql_rich("")
-        assert result == ""
+        result = highlight_sql_text("")
+        assert result.plain == ""
 
     def test_string_literals_styled(self) -> None:
         """String literals should be in the output with styling."""
-        result = highlight_sql_rich("WHERE name = 'John'")
+        result = highlight_sql_text("WHERE name = 'John'")
         assert "'John'" in result
-        # Should have markup tags around it
-        assert "[" in result
+        assert result.spans
 
     def test_numbers_styled(self) -> None:
         """Numeric literals should be in the output with styling."""
-        result = highlight_sql_rich("WHERE count > 42")
+        result = highlight_sql_text("WHERE count > 42")
         assert "42" in result
 
     def test_comments_styled(self) -> None:
         """SQL comments should be in the output with styling."""
-        result = highlight_sql_rich("SELECT 1 -- comment")
+        result = highlight_sql_text("SELECT 1 -- comment")
         assert "-- comment" in result
 
     def test_preserves_whitespace(self) -> None:
         """Highlighting should preserve whitespace."""
-        result = highlight_sql_rich("SELECT  id   FROM users")
-        # Remove markup and check original spacing preserved
-        plain = result.replace("\\[", "[")
-        # Should contain the original spacing
-        assert "  " in plain or "SELECT" in plain
+        sql = "SELECT  id   FROM users"
+        result = highlight_sql_text(sql)
+        assert result.plain == sql
 
-    def test_closing_tags_present(self) -> None:
-        """All opening tags should have closing tags."""
-        result = highlight_sql_rich("SELECT id FROM users")
-        # Count opening and closing tags
-        open_count = result.count("[") - result.count("\\[")
-        close_count = result.count("[/]")
-        # Should have equal opening (non-escaped) and closing tags
-        assert open_count == close_count * 2  # Each styled token has [style] and [/]
+    def test_spans_present(self) -> None:
+        """Styled SQL should carry Rich Text spans."""
+        result = highlight_sql_text("SELECT id FROM users")
+        assert result.spans
 
 
 class TestHighlightSqlRichFunctions:
-    """Tests for function detection in highlight_sql_rich() - T051."""
+    """Tests for function detection in highlight_sql_text() - T051."""
 
     def test_count_function_styled(self) -> None:
         """COUNT(*) should be styled as sql_function."""
-        result = highlight_sql_rich("SELECT COUNT(*) FROM users")
+        result = highlight_sql_text("SELECT COUNT(*) FROM users")
         assert "COUNT" in result
-        # Should have markup around it
-        assert "[" in result
+        assert result.spans
 
     def test_now_function_styled(self) -> None:
         """NOW() should be styled as sql_function."""
-        result = highlight_sql_rich("SELECT NOW()")
+        result = highlight_sql_text("SELECT NOW()")
         assert "NOW" in result
 
     def test_coalesce_function_styled(self) -> None:
         """COALESCE() should be styled as sql_function."""
-        result = highlight_sql_rich("SELECT COALESCE(name, 'default')")
+        result = highlight_sql_text("SELECT COALESCE(name, 'default')")
         assert "COALESCE" in result
 
     def test_aggregate_functions_styled(self) -> None:
         """SUM, AVG, MAX, MIN should be styled as sql_function."""
-        result = highlight_sql_rich("SELECT SUM(amount), AVG(amount), MAX(amount), MIN(amount)")
+        result = highlight_sql_text("SELECT SUM(amount), AVG(amount), MAX(amount), MIN(amount)")
         assert "SUM" in result
         assert "AVG" in result
         assert "MAX" in result
@@ -537,11 +526,11 @@ class TestHighlightSqlRichFunctions:
 
 
 class TestHighlightSqlRichKeywordCoverage:
-    """Tests for keyword coverage in highlight_sql_rich() - T052."""
+    """Tests for keyword coverage in highlight_sql_text() - T052."""
 
     def test_ddl_keywords_create_alter(self) -> None:
         """DDL keywords CREATE, ALTER should be highlighted."""
-        result = highlight_sql_rich(
+        result = highlight_sql_text(
             "CREATE TABLE users (id INT); ALTER TABLE users ADD COLUMN name TEXT"
         )
         assert "CREATE" in result
@@ -550,7 +539,7 @@ class TestHighlightSqlRichKeywordCoverage:
 
     def test_dml_keywords_select_insert(self) -> None:
         """DML keywords SELECT, INSERT should be highlighted."""
-        result = highlight_sql_rich("SELECT * FROM users; INSERT INTO users VALUES (1)")
+        result = highlight_sql_text("SELECT * FROM users; INSERT INTO users VALUES (1)")
         assert "SELECT" in result
         assert "INSERT" in result
         assert "INTO" in result
@@ -558,35 +547,33 @@ class TestHighlightSqlRichKeywordCoverage:
 
     def test_clause_keywords_where_join(self) -> None:
         """Clause keywords WHERE, JOIN should be highlighted."""
-        result = highlight_sql_rich("SELECT * FROM a JOIN b ON a.id = b.id WHERE a.active")
+        result = highlight_sql_text("SELECT * FROM a JOIN b ON a.id = b.id WHERE a.active")
         assert "WHERE" in result
         assert "JOIN" in result
         assert "ON" in result
 
     def test_logical_operators_and_or_not(self) -> None:
         """Logical operators AND, OR, NOT should be highlighted as keywords."""
-        result = highlight_sql_rich("SELECT * FROM users WHERE active AND NOT deleted OR archived")
+        result = highlight_sql_text("SELECT * FROM users WHERE active AND NOT deleted OR archived")
         assert "AND" in result
         assert "OR" in result
         assert "NOT" in result
 
 
 class TestHighlightSqlRichNoColor:
-    """Tests for NO_COLOR handling in highlight_sql_rich() - T028, T029."""
+    """Tests for NO_COLOR handling in highlight_sql_text() - T028, T029."""
 
-    def test_no_color_returns_escaped_brackets_only(self) -> None:
-        """With NO_COLOR=1, should return SQL with only bracket escaping."""
+    def test_no_color_returns_plain_text(self) -> None:
+        """With NO_COLOR=1, return unstyled SQL Text."""
         with patch.dict(os.environ, {"NO_COLOR": "1"}, clear=False):
             # Need to reload the cached check
             from pgtail_py import utils
 
             utils._color_disabled = None  # Clear cache
             try:
-                result = highlight_sql_rich("SELECT arr[1] FROM users")
-                # Should have escaped bracket
-                assert "\\[1]" in result
-                # Should NOT have Rich markup tags (closing tag pattern)
-                assert "[/]" not in result
+                result = highlight_sql_text("SELECT arr[1] FROM users")
+                assert result.plain == "SELECT arr[1] FROM users"
+                assert not result.spans
             finally:
                 utils._color_disabled = None  # Clear cache again
 
@@ -597,9 +584,8 @@ class TestHighlightSqlRichNoColor:
 
             utils._color_disabled = None
             try:
-                result = highlight_sql_rich("SELECT id FROM users")
-                # No closing tags means no Rich markup
-                assert "[/" not in result
+                result = highlight_sql_text("SELECT id FROM users")
+                assert not result.spans
                 # But should have the SQL content
                 assert "SELECT" in result
                 assert "FROM" in result
@@ -608,10 +594,10 @@ class TestHighlightSqlRichNoColor:
 
 
 class TestHighlightSqlRichWithTheme:
-    """Tests for theme integration in highlight_sql_rich() - T033-T035."""
+    """Tests for theme integration in highlight_sql_text() - T033-T035."""
 
     def test_uses_passed_theme_for_color_lookup(self) -> None:
-        """highlight_sql_rich() should use the passed theme for colors."""
+        """highlight_sql_text() should use the passed theme for colors."""
         # Create a custom theme with distinctive colors
         custom_theme = Theme(
             name="test-theme",
@@ -628,15 +614,15 @@ class TestHighlightSqlRichWithTheme:
                 "sql_identifier": ColorStyle(fg="green"),
             },
         )
-        result = highlight_sql_rich("SELECT id FROM users", theme=custom_theme)
-        # Should have magenta in output for keywords
-        assert "magenta" in result or "bold" in result
+        result = highlight_sql_text("SELECT id FROM users", theme=custom_theme)
+        # Should have magenta/bold style for keywords
+        assert any(str(span.style) == "bold magenta" for span in result.spans)
 
     def test_uses_global_theme_when_none_passed(self) -> None:
-        """highlight_sql_rich() should use global ThemeManager when theme is None."""
-        result = highlight_sql_rich("SELECT id FROM users", theme=None)
+        """highlight_sql_text() should use global ThemeManager when theme is None."""
+        result = highlight_sql_text("SELECT id FROM users", theme=None)
         # Should still produce styled output (using default theme)
-        assert "[" in result
+        assert result.spans
         assert "SELECT" in result
 
     def test_graceful_fallback_for_missing_sql_keys(self) -> None:
@@ -655,7 +641,7 @@ class TestHighlightSqlRichWithTheme:
                 # No sql_* keys defined
             },
         )
-        result = highlight_sql_rich("SELECT id FROM users", theme=minimal_theme)
+        result = highlight_sql_text("SELECT id FROM users", theme=minimal_theme)
         # Should still contain the SQL text
         assert "SELECT" in result
         assert "id" in result
@@ -670,11 +656,11 @@ class TestHighlightSqlRichWithTheme:
 
 
 class TestHighlightSqlRichLiterals:
-    """Tests for literal distinction in highlight_sql_rich() - T015-T017."""
+    """Tests for literal distinction in highlight_sql_text() - T015-T017."""
 
     def test_string_literals_styled_distinctly_from_identifiers(self) -> None:
         """String literals 'John' should be styled distinctly from identifiers (T015)."""
-        result = highlight_sql_rich("SELECT name FROM users WHERE name = 'John'")
+        result = highlight_sql_text("SELECT name FROM users WHERE name = 'John'")
         # Check that 'John' is in output
         assert "'John'" in result
         # Check that name (identifier) is also in output
@@ -683,49 +669,47 @@ class TestHighlightSqlRichLiterals:
 
     def test_numeric_literals_styled_distinctly(self) -> None:
         """Numeric literals like 42 should be styled distinctly (T016)."""
-        result = highlight_sql_rich("SELECT id FROM users WHERE age = 42")
+        result = highlight_sql_text("SELECT id FROM users WHERE age = 42")
         assert "42" in result
-        # Should have markup
-        assert "[" in result
+        assert result.spans
 
     def test_dollar_quoted_strings_styled_as_strings(self) -> None:
         """Dollar-quoted strings $$body$$ should be styled as strings (T017)."""
-        result = highlight_sql_rich("SELECT $$body content$$ FROM table")
+        result = highlight_sql_text("SELECT $$body content$$ FROM table")
         assert "$$body content$$" in result
 
     def test_various_string_formats(self) -> None:
         """Various string literal formats should all be styled."""
         # Single quotes
-        result1 = highlight_sql_rich("SELECT 'hello'")
+        result1 = highlight_sql_text("SELECT 'hello'")
         assert "'hello'" in result1
 
         # Double-dollar quotes
-        result2 = highlight_sql_rich("SELECT $$hello$$")
+        result2 = highlight_sql_text("SELECT $$hello$$")
         assert "$$hello$$" in result2
 
         # Tagged dollar quotes
-        result3 = highlight_sql_rich("SELECT $tag$hello$tag$")
+        result3 = highlight_sql_text("SELECT $tag$hello$tag$")
         assert "$tag$hello$tag$" in result3
 
     def test_integer_and_float_literals(self) -> None:
         """Both integer and float literals should be styled."""
-        result = highlight_sql_rich("SELECT * FROM t WHERE x = 42 AND y = 3.14")
+        result = highlight_sql_text("SELECT * FROM t WHERE x = 42 AND y = 3.14")
         assert "42" in result
         assert "3.14" in result
 
 
 class TestHighlightSqlRichEdgeCases:
-    """Edge case tests for highlight_sql_rich() - T041-T045."""
+    """Edge case tests for highlight_sql_text() - T041-T045."""
 
     def test_sql_with_nested_brackets(self) -> None:
-        """SQL with nested brackets like arr[1][2] should escape all brackets."""
-        result = highlight_sql_rich("SELECT arr[1][2] FROM table")
-        # Should have multiple escaped brackets
-        assert result.count("\\[") >= 2
+        """SQL with nested brackets like arr[1][2] renders back unchanged."""
+        sql = "SELECT arr[1][2] FROM table"
+        assert highlight_sql_text(sql).plain == sql
 
     def test_malformed_sql_with_unrecognized_tokens(self) -> None:
         """Malformed SQL should highlight recognized tokens and display unknown plain."""
-        result = highlight_sql_rich("SELECT @@@ FROM users")
+        result = highlight_sql_text("SELECT @@@ FROM users")
         # SELECT and FROM should be highlighted
         assert "SELECT" in result
         assert "FROM" in result
@@ -745,7 +729,7 @@ class TestHighlightSqlRichEdgeCases:
         assert len(sql) >= 50000, f"SQL length is only {len(sql)}"
 
         start = time.perf_counter()
-        result = highlight_sql_rich(sql)
+        result = highlight_sql_text(sql)
         elapsed_ms = (time.perf_counter() - start) * 1000
 
         # Verify result is valid
@@ -755,15 +739,15 @@ class TestHighlightSqlRichEdgeCases:
 
     def test_dollar_quoted_strings(self) -> None:
         """Dollar-quoted strings should be styled correctly."""
-        result = highlight_sql_rich("SELECT $tag$body content$tag$ FROM table")
+        result = highlight_sql_text("SELECT $tag$body content$tag$ FROM table")
         assert "$tag$body content$tag$" in result
 
     def test_line_comments(self) -> None:
         """Line comments (--) should be styled."""
-        result = highlight_sql_rich("SELECT 1 -- this is a comment")
+        result = highlight_sql_text("SELECT 1 -- this is a comment")
         assert "-- this is a comment" in result
 
     def test_block_comments(self) -> None:
         """Block comments (/* */) should be styled."""
-        result = highlight_sql_rich("SELECT /* comment */ 1 FROM users")
+        result = highlight_sql_text("SELECT /* comment */ 1 FROM users")
         assert "/* comment */" in result

--- a/tests/test_tail_log.py
+++ b/tests/test_tail_log.py
@@ -101,7 +101,7 @@ class TestTailLogStripMarkup:
     def test_strip_markup_full_sql_flow(self) -> None:
         """Full SQL yank flow: Rich markup → _strip_markup() → clean SQL (T027)."""
         widget = TailLog()
-        # Simulated Rich markup output from highlight_sql_rich
+        # Simulated Rich markup output from highlight_sql_text
         markup = "[bold blue]SELECT[/] [cyan]arr[/]\\[1] [bold blue]FROM[/] [cyan]users[/]"
         result = widget._strip_markup(markup)
         # Should be plain SQL with proper brackets

--- a/tests/test_tail_rich.py
+++ b/tests/test_tail_rich.py
@@ -148,16 +148,16 @@ class TestFormatEntryAsRich:
 class TestFormatEntryCompact:
     """Tests for format_entry_compact function."""
 
-    def test_returns_string(self, sample_entry: LogEntry) -> None:
-        """Test that function returns a string."""
+    def test_returns_text(self, sample_entry: LogEntry) -> None:
+        """Test that function returns Rich Text."""
         result = format_entry_compact(sample_entry)
-        assert isinstance(result, str)
+        assert isinstance(result, Text)
 
     def test_single_line(self, sample_entry: LogEntry) -> None:
         """Test that compact format is single line (no newlines in main content)."""
         result = format_entry_compact(sample_entry)
         # Main message should be on one line
-        lines = result.split("\n")
+        lines = result.plain.split("\n")
         assert len(lines) >= 1
         assert "duplicate key value" in lines[0]
 
@@ -178,7 +178,7 @@ class TestFormatEntryCompactSqlHighlighting:
     """Tests for SQL highlighting in format_entry_compact() - T014."""
 
     def test_sql_statement_highlighted(self) -> None:
-        """SQL statement in message should be highlighted with Rich markup."""
+        """SQL statement in message should be highlighted with Rich spans."""
         entry = LogEntry(
             raw="2024-01-15 10:00:00.000 UTC LOG: statement: SELECT * FROM users",
             timestamp=datetime(2024, 1, 15, 10, 0, 0),
@@ -188,8 +188,7 @@ class TestFormatEntryCompactSqlHighlighting:
             sql_state=None,
         )
         result = format_entry_compact(entry)
-        # Should have Rich markup tags
-        assert "[" in result
+        assert result.spans
         # Should contain the SQL keywords
         assert "SELECT" in result
         assert "FROM" in result
@@ -208,7 +207,7 @@ class TestFormatEntryCompactSqlHighlighting:
         assert "connection received" in result
 
     def test_sql_with_brackets_escaped(self) -> None:
-        """SQL with array brackets should escape brackets properly."""
+        """SQL array subscripts render back intact within a full log line."""
         entry = LogEntry(
             raw="2024-01-15 10:00:00.000 UTC LOG: statement: SELECT arr[1] FROM t",
             timestamp=datetime(2024, 1, 15, 10, 0, 0),
@@ -218,8 +217,7 @@ class TestFormatEntryCompactSqlHighlighting:
             sql_state=None,
         )
         result = format_entry_compact(entry)
-        # Bracket should be escaped to prevent Rich parsing errors
-        assert "\\[" in result
+        assert "SELECT arr[1] FROM t" in result.plain
 
     def test_execute_statement_detected(self) -> None:
         """Execute statement pattern should be detected and highlighted."""
@@ -234,11 +232,10 @@ class TestFormatEntryCompactSqlHighlighting:
         result = format_entry_compact(entry)
         assert "SELECT" in result
         assert "FROM" in result
-        # Should have Rich markup
-        assert "[" in result
+        assert result.spans
 
     def test_message_with_brackets_no_sql_escaped(self) -> None:
-        """Non-SQL message with brackets should be escaped."""
+        """Non-SQL message with brackets stays markup-safe and intact."""
         entry = LogEntry(
             raw="LOG: array value [1, 2, 3] received",
             timestamp=None,
@@ -248,8 +245,7 @@ class TestFormatEntryCompactSqlHighlighting:
             sql_state=None,
         )
         result = format_entry_compact(entry)
-        # Brackets should be escaped
-        assert "\\[" in result
+        assert "array value [1, 2, 3] received" in result.plain
 
 
 class TestFormatEntryCompactThemeSwitch:
@@ -257,7 +253,7 @@ class TestFormatEntryCompactThemeSwitch:
 
     def test_theme_switch_updates_sql_colors(self) -> None:
         """Simulating theme switch should update SQL colors in output (T040)."""
-        from pgtail_py.highlighters.sql import _get_theme_manager, highlight_sql_rich
+        from pgtail_py.highlighters.sql import _get_theme_manager, highlight_sql_text
         from pgtail_py.themes import BUILTIN_THEMES
 
         # Get the theme manager
@@ -265,15 +261,15 @@ class TestFormatEntryCompactThemeSwitch:
 
         # Switch to dark theme
         tm._current_theme = BUILTIN_THEMES["dark"]
-        result_dark = highlight_sql_rich("SELECT id FROM users")
+        result_dark = highlight_sql_text("SELECT id FROM users")
 
         # Switch to monokai theme
         tm._current_theme = BUILTIN_THEMES["monokai"]
-        result_monokai = highlight_sql_rich("SELECT id FROM users")
+        result_monokai = highlight_sql_text("SELECT id FROM users")
 
-        # Both should have markup
-        assert "[" in result_dark
-        assert "[" in result_monokai
+        # Both should have spans
+        assert result_dark.spans
+        assert result_monokai.spans
 
         # The colors should be different (dark uses ansiblue, monokai uses #f92672)
         # We just verify the outputs are different

--- a/tests/test_tail_textual.py
+++ b/tests/test_tail_textual.py
@@ -54,6 +54,41 @@ def mock_state() -> MagicMock:
     return state
 
 
+class TestUpdateStatusResilience:
+    """Regression tests for _update_status widget-query safety."""
+
+    @pytest.mark.asyncio
+    async def test_update_status_safe_when_widgets_unmounted(
+        self, mock_instance: Instance, mock_state: MagicMock, tmp_path: Path
+    ) -> None:
+        """_update_status must no-op when #header/#status aren't in the DOM.
+
+        The consumer worker and rebuilds call _update_status from outside the
+        mounted window -- before compose finishes on startup, or after the
+        widgets are torn down on shutdown. It must not raise NoMatches (which
+        would surface as WorkerFailed and crash the app).
+        """
+        log_file = tmp_path / "postgresql.log"
+        log_file.write_text("")
+
+        app = TailApp(state=mock_state, instance=mock_instance, log_path=log_file)
+
+        with patch("pgtail_py.tail_textual.LogTailer") as mock_tailer_class:
+            mock_tailer = MagicMock()
+            mock_tailer.get_entry = MagicMock(return_value=None)
+            mock_tailer.file_unavailable = False
+            mock_tailer.file_permission_denied = False
+            mock_tailer_class.return_value = mock_tailer
+
+            async with app.run_test():
+                # Reproduce the teardown window: remove the display widgets.
+                await app.query_one("#header").remove()
+                await app.query_one("#status").remove()
+
+                # Must return cleanly rather than raising NoMatches.
+                app._update_status()
+
+
 class TestTailAppHelpOverlay:
     """Tests for help overlay functionality."""
 


### PR DESCRIPTION
Running a COPY with a Windows path in psql crashed the tail view:

    copy (select * from pg_sequences) to 'c:\users\alexj\sequence_output.txt';

Log lines are rendered through Rich markup, and the highlighters wrap matched tokens as `[style]token[/]`. When the text right before a tag ends in a backslash, as `...alexj\` does, Rich reads `\[style]` as an escaped literal `[`, so the tag never opens and its `[/]` has nothing to close. That `MarkupError` fired inside the render loop and took the whole app down.

Escaping around it turns out to be a dead end. Rich only collapses backslash runs that sit before something it already thinks is a tag, and it never collapses `\\`, so no string-escaping scheme round-trips every case: trailing backslashes, `\[123]`, and multi-backslash runs each either drop a slash or still raise the error.

So rather than build markup strings and parse log content back out of them, the render path now builds Rich Text and appends log content as literal spans. Content is never interpreted as markup, which removes the class of bug rather than patching one shape of it. Markup parsing stays only for trusted UI strings.

This also fixes a separate crash found on the way: the consumer worker could call `_update_status` and look up `#header` while the widget was unmounted during startup or shutdown, raising `NoMatches` and killing the worker. It now does nothing when the widgets aren't there.

Fixes: #40
